### PR TITLE
Fix #events-logs overflowing the viewport on PC/notebook layouts

### DIFF
--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -114,7 +114,9 @@ body > canvas {
 	}
 
 	section.section-container#events-logs {
-		width: calc(100vw - 90px - 393px - 120px);
+		/* sidebar (90) + #events width (393) + #events margins (60)
+		   + #events-logs margins (180) = 723px reserved */
+		width: calc(100vw - 723px);
 		min-width: 600px;
 		max-width: 1179px;
 	}
@@ -257,6 +259,22 @@ body > canvas {
 		padding-bottom: 2em;
 		width: calc(100vw - 90px);
 		box-sizing: border-box;
+	}
+
+	/* EventsView: the side-by-side events (393px) + events-logs (>=600px)
+	   layout doesn't fit in this range — stack them and let each take
+	   the full content width. */
+	#eventsView.content-container {
+		flex-direction: column;
+	}
+
+	section.section-container#events,
+	section.section-container#events-logs {
+		width: calc(100% - 40px);
+		max-width: calc(100% - 40px);
+		min-width: 0;
+		margin: 20px;
+		height: auto;
 	}
 }
 


### PR DESCRIPTION
- ≤1599px small-desktop rule for #events-logs was reserving only 120px for margins when the actual horizontal margins around #events (60px) and #events-logs (180px) total 240px. The undersized calc left the section ~120px wider than the available content area, so its right edge ran off the right side of the page. Updated to subtract 723px total (sidebar + #events width + both margin sums) with a clarifying comment.
- Extended the EventsView column-stack rule from ≤1023px to ≤1199px. In the 1024-1199px range the side-by-side layout still couldn't fit (#events 393 + #events-logs min 600 + 240 margins = 1233px > content area), causing the same overflow. Now #events and #events-logs each take full content width below 1200px and stack vertically.