### PR TITLE
Retarget Build workflow from master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
The default branch was renamed master -> main. The workflow's pull_request and push triggers still listed [master], so the workflow could no longer be invoked at all — every PR opened against main would show the required "build" status check as missing, blocking the ruleset-enforced merge.

For the PR introducing this change to itself pass the build check, GitHub Actions reads the workflow file from the merged commit (PR HEAD), not the base branch, so updating the triggers inside the PR is enough to make the build run for this very PR.