### PR TITLE
Fix PWA icon being white-on-white on installed mobile home screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,15 +2,15 @@
 <html lang="en">
 	<head>
 		<meta charset="UTF-8" />
-		<link rel="icon" type="image/svg+xml" href="/faction-logos/union.svg" />
-		<link rel="apple-touch-icon" href="/faction-logos/union.svg" />
+		<link rel="icon" type="image/svg+xml" href="/icons/pwa-icon.svg" />
+		<link rel="apple-touch-icon" href="/icons/pwa-icon.svg" />
 		<meta name="theme-color" content="#991e2a" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<meta property="og:type" content="website" />
     <meta property="og:url" content="https://contrafatores.netlify.app/">
     <meta property="og:title" content="UN Relatório de Missões">
     <meta property="og:description" content="UN | RELATÓRIO DE MISSÕES">
-    <meta property="og:image" content="/faction-logos/union.svg">
+    <meta property="og:image" content="/icons/pwa-icon.svg">
     <title>UN | CENTRAL DE CONTROLE</title>
 	</head>
 

--- a/public/icons/pwa-icon.svg
+++ b/public/icons/pwa-icon.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Dedicated PWA / favicon icon. Combines a solid red background
+     with the white Union logo so the home-screen icon is legible
+     regardless of the launcher's wallpaper, and so a maskable
+     crop (~80% center safe zone) still shows the brand color
+     instead of the OS's default white pad. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1080 1080">
+	<rect width="1080" height="1080" fill="#991e2a"/>
+	<g fill="#ffffff">
+		<path d="M911.43,538.1L732.16,218.95c-1.67-2.97-4.81-4.81-8.22-4.81H348.03c-7.22,0-11.75,7.78-8.2,14.06l173.85,307.5c1.65,2.92,1.62,6.5-0.07,9.4L334.06,851.67c-3.68,6.28,0.85,14.18,8.13,14.18h376.09c3.34,0,6.42-1.76,8.12-4.64L911.33,547.5C913.04,544.61,913.07,541.03,911.43,538.1z"/>
+		<path d="M298.99,305.86L168.58,536.53c-1.65,2.92-1.62,6.5,0.07,9.4l130.41,222.68c4.86,8.29,17.55,4.85,17.55-4.76V310.5C316.62,300.81,303.76,297.43,298.99,305.86z"/>
+	</g>
+</svg>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,23 +30,20 @@ export default defineConfig({
         short_name: "UN Briefing",
         description: "Lancer mission briefing dashboard",
         theme_color: "#991e2a",
-        background_color: "#ffffff",
+        // background_color is the PWA splash-screen color, separate
+        // from the icon. Keep it on-brand red so the splash matches
+        // the icon and the loading state doesn't flash white.
+        background_color: "#991e2a",
         display: "standalone",
         orientation: "any",
         start_url: "./",
         scope: "./",
         icons: [
           {
-            src: "faction-logos/union.svg",
+            src: "icons/pwa-icon.svg",
             sizes: "any",
             type: "image/svg+xml",
-            purpose: "any",
-          },
-          {
-            src: "faction-logos/union-white.svg",
-            sizes: "any",
-            type: "image/svg+xml",
-            purpose: "maskable",
+            purpose: "any maskable",
           },
         ],
       },


### PR DESCRIPTION
The previous manifest pointed at union-white.svg as the maskable icon and at union.svg as the any-purpose icon. On Android launchers that apply the manifest's background_color (white) behind a maskable icon, union-white.svg's white paths landed on a white field — invisible. On iOS the same happened on light wallpapers because the SVG had no opaque background of its own.

Created public/icons/pwa-icon.svg: a dedicated 1080x1080 icon that bakes a solid --primary-color (#991e2a) <rect> as the background and draws the Union logo in white on top. With the background built into the asset itself, the icon stays legible regardless of the launcher's own background handling and survives the maskable safe-zone crop (the logo sits well within the 80% center area).

Manifest changes

- Switched the icons array to a single entry pointing at the new pwa-icon.svg with purpose "any maskable" — one asset now covers both regular and maskable consumers.
- Flipped background_color from #ffffff to #991e2a so the splash screen the OS shows during PWA boot matches the icon and the loading state doesn't flash white before the app paints.

index.html now uses the same pwa-icon.svg for <link rel="icon">, <link rel="apple-touch-icon"> and og:image — the browser tab favicon, the iOS home-screen icon, and social shares are all visually consistent and all readable.