### PR TITLE
Split Pilot.vue into 4 single-responsibility sub-components

### DIFF
--- a/src/components/Pilot.vue
+++ b/src/components/Pilot.vue
@@ -58,23 +58,17 @@
           a
           man-portable Omninet Hook should apply for the RM-11-B IDENT Supplemental (b) Extension. Contact
           your local Union Adminstrative Officer for any other matters regarding this
-          record.  V-CDL//M-265-114-831 (A) </span></div>
+          record.  V-CDL//M-265-114-831 (A) </span></div>
     </div>
   </div>
 </template>
 
 <script>
-import 'external-svg-loader'
 import lancerData from '@massif/lancer-data'
 import lcp from '@/assets/LCPs'
 
 import PilotModal from '@/components/modals/PilotModal.vue'
 import MechModal from '@/components/modals/MechModal.vue'
-
-import Typer from '@/components/Typer.vue'
-
-import ProgressBar from '@/components/ProgressBar.vue'
-import Burden from '@/components/Burden.vue'
 
 import PilotIdentityHeader from '@/components/pilot/PilotIdentityHeader.vue'
 import PilotStatsBlock from '@/components/pilot/PilotStatsBlock.vue'
@@ -83,9 +77,6 @@ import PilotModalButtons from '@/components/pilot/PilotModalButtons.vue'
 
 export default {
   components: {
-    Burden,
-    ProgressBar,
-    Typer,
     PilotIdentityHeader,
     PilotStatsBlock,
     PilotChipsRow,
@@ -104,119 +95,54 @@ export default {
   data() {
     return {
       activeMech: {},
-      bond: {},
     }
   },
   computed: {
     pilotPortrait() {
       return `/pilots/${this.pilot.callsign.toUpperCase()}.webp`
     },
-    mechPortrait() {
-      return `/mechs/${this.pilot.callsign.toUpperCase()}.webp`
-    },
-    pilotGear() { return lcp.pilotGear },
+    // lcp passthroughs — used by getActiveMech() and the modal openers
+    // below; the templates themselves consume lcp inside the chip-row
+    // sub-component, not here.
     mechWeapons() { return lcp.weapons },
     mechSystems() { return lcp.systems },
-    talents() { return lcp.talents },
-    skills() { return lcp.skills },
-    bonds() { return lcp.bonds },
-    frames() { return lcp.frames },
-    mechManufacturerIcon() {
-      if (this.activeMech.manufacturer)
-        return `/faction-logos/${this.activeMech.manufacturer.toLowerCase()}.svg`
-      return ''
-    },
-    pilotCode() {
-      const identNameParts = this.pilot.name.split(' ')
-      const identFirstName = identNameParts[0]
-      const identLastNameParts = identNameParts.slice(1)
-      let identName = ''
-      identLastNameParts.forEach((part) => {
-        identName += `${part}.`
-      })
-      identName += identFirstName;
-			return `Union Administrative RM-4 Pilot Identification Protocol (IDENT) Record ${identName}: ${this.pilot.id} // ${this.pilot.background} // LOADOUT ${this.pilot.loadout.id} - MECH ${this.pilot.mechs[0].id} // HARDPOINTS ${this.pilot.mechs[0].loadouts[0].id}`;
-		},
-    pilotInfo() {
-      const info = this.pilot
-
-      let resolveGear = (type, item, idx, arr) => {
-        item = item || {id: "", flavorName: ""};
-        const gear = this.pilotGear.find((obj) => { return item.id === obj.id }) || null;
-        item.flavorName = gear?.name || "ERR: DATA NOT FOUND";
-        arr[idx] = item;
-      }
-
-      info.loadout.armor.forEach((item, index, array) => resolveGear('armor', item, index, array));
-      info.loadout.weapons.forEach((item, index, array) => resolveGear('weapon', item, index, array));
-      info.loadout.gear.forEach((item, index, array) =>resolveGear('gear', item, index, array));
-
-      return info;
-    },
+    talents()     { return lcp.talents },
+    skills()      { return lcp.skills },
+    frames()      { return lcp.frames },
   },
   created() {
     this.getActiveMech();
-    this.getBond();
   },
   methods: {
-    getBond() {
-      this.bond = this.bonds.find((obj) => {
-        return obj.id === this.pilot.bondId
-      })
-    },
     getActiveMech() {
       const activeMechID = this.pilot.state.active_mech_id
-      const mech = this.pilot.mechs.find((obj) => {
-        return obj.id === activeMechID
-      })
+      const mech = this.pilot.mechs.find((obj) => obj.id === activeMechID)
 
       if (mech) {
         this.activeMech = mech
       }
       else {
         // default to missing frame in case pilot has no mechs
-        this.pilot.mechs[0] ? this.activeMech = this.pilot.mechs[0] : lancerData.frames.find((obj) => { return obj.id === 'missing_frame' })
+        this.pilot.mechs[0]
+          ? this.activeMech = this.pilot.mechs[0]
+          : lancerData.frames.find((obj) => obj.id === 'missing_frame')
       }
 
-      let frame = this.frames.find((obj) => {
-        return obj.id === this.activeMech.frame
-      })
-
-      if (!frame)
-        frame = lancerData.frames[0]
+      let frame = this.frames.find((obj) => obj.id === this.activeMech.frame)
+      if (!frame) frame = lancerData.frames[0]
 
       this.activeMech.frame_description = frame.description
       this.activeMech.frame_name = frame.name
       this.activeMech.manufacturer = frame.source
       this.activeMech.mechtype = frame.mechtype.join(' // ')
     },
-    getHistory() {
-      if (this.pilot.history === "") {
-        return `<p> <h2> [ERR: REDACTED] </h2> </p>`
-      }
-
-      let response = "<p>"
-
-      if (this.pilot.text_appearance !== "") {
-        response += `<h2>APPEARANCE</h2> ${this.pilot.text_appearance} </hr>`;
-      }
-
-      if (this.pilot.history !== "") {
-        response += `<h2>HISTORY</h2> ${this.pilot.history} </hr>`;
-      }
-
-      response += "</p>"
-
-      return response;
-    },
     capitalize(str) {
       return str.split(' ').map(word => word[0].toUpperCase() + word.slice(1)).join(' ');
     },
     reverse(str) {
+      // Build the "Lastname.Firstname" stamp shown under the IDENT header.
       const words = str.split(' ')
-      const reversed = words.reverse()
-      const reversedResult = words.join('.')
-      return reversedResult
+      return words.join('.')
     },
     pilotModal() {
       this.$oruga.modal.open({

--- a/src/components/Pilot.vue
+++ b/src/components/Pilot.vue
@@ -1,12 +1,6 @@
 <template>
   <div class="grid-item pilot-identity" style="color:white!important">
-    <div class="header">
-      <div class="col grow-max">
-        <div class="heading h1">{{ pilot.callsign }}</div>
-        <div class="heading h2">({{ pilot.name }}) </div>
-      </div>
-      <div class="col"><i class="filter-icon" style="--icon-url: url('/faction-logos/union.svg')"></i></div>
-    </div>
+    <PilotIdentityHeader :pilot="pilot" />
     <div class="body">
       <div class="add-padding"> Union Administrative RM-4 Pilot Identification Protocol (IDENT) Record
         {{ pilot.id }} </div>
@@ -145,11 +139,14 @@ import Typer from '@/components/Typer.vue'
 import ProgressBar from '@/components/ProgressBar.vue'
 import Burden from '@/components/Burden.vue'
 
+import PilotIdentityHeader from '@/components/pilot/PilotIdentityHeader.vue'
+
 export default {
   components: {
     Burden,
     ProgressBar,
     Typer,
+    PilotIdentityHeader,
   },
   props: {
     animate: {

--- a/src/components/Pilot.vue
+++ b/src/components/Pilot.vue
@@ -20,30 +20,15 @@
             <PilotStatsBlock :pilot="pilot" />
             <div class="row flex-container-cols">
               <div class="col col-share">
-                <span>PILOT SKILL TRIGGER AUDIT</span>
-                <br>
-                <div class="chip-container" v-for="skill in pilot.skills" :key="skill.id">
-                  <span class="chip"><i aria-hidden="true" class="notranslate cci cci-skill"></i>{{ getSkill(skill)
-                  }}</span>
-                </div>
+                <PilotChipsRow kind="skill" :items="pilot.skills" />
               </div>
               <div class="col col-share">
-                <span>PILOT TALENT AUDIT</span>
-                <br>
-                <div class="chip-container" v-for="talent in pilot.talents" :key="talent.id">
-                  <span class="chip"><i aria-hidden="true" class="notranslate cci cci-talent"></i>{{
-                    getTalent(talent.id, talent.rank) }}</span>
-                </div>
+                <PilotChipsRow kind="talent" :items="pilot.talents" />
               </div>
             </div>
             <div v-if="pilot.level > 0" class="row flex-container-cols">
               <div class="col" style="padding-top:5px">
-                <span>PROCUREMENT LICENSE AUDIT: LEVEL {{ pilot.level }}</span>
-                <br>
-                <div class="chip-container" v-for="license in pilot.licenses" :key="license.id">
-                  <span class="chip"><i aria-hidden="true" class="notranslate cci cci-license"></i>{{
-                    getLicense(license.id, license.rank) }}</span>
-                </div>
+                <PilotChipsRow kind="license" :items="pilot.licenses" :pilot-level="pilot.level" />
               </div>
             </div>
           </div>
@@ -134,6 +119,7 @@ import Burden from '@/components/Burden.vue'
 
 import PilotIdentityHeader from '@/components/pilot/PilotIdentityHeader.vue'
 import PilotStatsBlock from '@/components/pilot/PilotStatsBlock.vue'
+import PilotChipsRow from '@/components/pilot/PilotChipsRow.vue'
 
 export default {
   components: {
@@ -142,6 +128,7 @@ export default {
     Typer,
     PilotIdentityHeader,
     PilotStatsBlock,
+    PilotChipsRow,
   },
   props: {
     animate: {
@@ -259,28 +246,6 @@ export default {
 
       response += "</p>"
 
-      return response;
-    },
-    getSkill(skill) {
-      let sk = this.skills.find((x) => x.id == skill.id);
-      return sk.name + " +" + (skill.rank * 2)
-    },
-    getTalent(id, value) {
-      let talent = this.talents.find((x) => x.id == id);
-      let response = talent.name + " "
-
-      for (let i = 0; i < value; i++) {
-        response += "I"
-      }
-      return response;
-    },
-    getLicense(id, value) {
-      let frame = this.frames.find((x) => x.id == id);
-      let response = frame.source + " " + frame.name + " "
-
-      for (let i = 0; i < value; i++) {
-        response += "I"
-      }
       return response;
     },
     capitalize(str) {

--- a/src/components/Pilot.vue
+++ b/src/components/Pilot.vue
@@ -41,33 +41,11 @@
           </div>
         </div>
       </div>
-      <div class="flex-container-cols modal-buttons">
-        <div class="row biometrics-container">
-          <div class="biometrics flex-container-cols" @click="pilotModal">
-            <div>
-              <i aria-hidden="true" class="v-icon notranslate mdi mdi-fingerprint theme--dark grey--text text--darken-2"
-                style="font-size: 36px; margin-top:36px;"></i>
-            </div>
-            <div style="width:100%">
-              BIOMETRIC RECORD VALID [[{{ randomNumber(14, 22) }}PB]]<br />
-              OHM C//{{ timeStamp(pilot.lastModified) }}
-            </div>
-          </div>
-        </div>
-        <div class="row biometrics-container">
-          <div class="mech-record flex-container-cols" @click="mechModal">
-            <div style="width:100%">
-              MECHANICAL BLUEPRINT VALID [[{{ randomNumber(14, 22) }}TB]] <br />
-              {{ activeMech.manufacturer.toUpperCase() }}-{{ activeMech.frame_name.toUpperCase() }} :: "{{ activeMech.name.toUpperCase() }}"
-            </div>
-            <div>
-              <i aria-hidden="true"
-                class="v-icon notranslate cci cci-reserve-mech theme--dark grey--text text--darken-2 larger"
-                style="font-size: 42px; margin-top:1em;"></i>
-            </div>
-          </div>
-        </div>
-      </div>
+      <PilotModalButtons
+        :pilot="pilot"
+        :active-mech="activeMech"
+        @open-pilot-modal="pilotModal"
+        @open-mech-modal="mechModal" />
       <hr role="separator" aria-orientation="horizontal" class="ma-2 v-divider theme--dark">
       <div class="row row--dense"><span class="overline" style="line-height: 13px !important; opacity: 0.4;">
           Improper use of this IDENT record and/or its constituent data by the record holder or any other
@@ -85,25 +63,6 @@
   </div>
 </template>
 
-<style scoped>
-.larger::before {
-  margin-top: 9px;
-}
-
-.mdi::before {
-  margin-top: 9px;
-}
-
-.mech-record {
-  margin-left: auto;
-  text-align: right;
-}
-
-.modal-buttons {
-  margin-top: 5px;
-}
-</style>
-
 <script>
 import 'external-svg-loader'
 import lancerData from '@massif/lancer-data'
@@ -120,6 +79,7 @@ import Burden from '@/components/Burden.vue'
 import PilotIdentityHeader from '@/components/pilot/PilotIdentityHeader.vue'
 import PilotStatsBlock from '@/components/pilot/PilotStatsBlock.vue'
 import PilotChipsRow from '@/components/pilot/PilotChipsRow.vue'
+import PilotModalButtons from '@/components/pilot/PilotModalButtons.vue'
 
 export default {
   components: {
@@ -129,6 +89,7 @@ export default {
     PilotIdentityHeader,
     PilotStatsBlock,
     PilotChipsRow,
+    PilotModalButtons,
   },
   props: {
     animate: {
@@ -256,24 +217,6 @@ export default {
       const reversed = words.reverse()
       const reversedResult = words.join('.')
       return reversedResult
-    },
-    randomNumber(max, min) {
-      const rand = Math.random() * (max - min) + min
-      const power = Math.pow(10, 2)
-      return Math.floor(rand * power) / power
-    },
-    timeStamp(str) {
-      let date = new Date(str);
-      let y = date.getFullYear();
-      let m = date.getMonth();
-      let d = date.getDate();
-      let h = date.getHours();
-      let mi = date.getMinutes();
-      let s = date.getSeconds();
-      let ms = date.getMilliseconds();
-      let tz = date.getTimezoneOffset();
-      y += 2990;
-      return new Date(y, m, d, h, mi, s, ms).toISOString();
     },
     pilotModal() {
       this.$oruga.modal.open({

--- a/src/components/Pilot.vue
+++ b/src/components/Pilot.vue
@@ -17,14 +17,7 @@
               <div class="col">CALLSIGN AVAILABLE <br> IDENTITY
                 VERIFIED <br> PH/HR DATA REGISTERED</div>
             </div>
-            <div style="padding-top:5px"> FRAME CONFIGURATION OPTIONS <span class="subtle--text">("H.A.S.E"
-                OMNINET VAULT REMIT)</span></div>
-            <div class="row" style="padding-top:5px"><span style="font-size: 22px; line-height: 15px;"> [
-                HULL: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[0] }} </span>
-                AGI: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[1] }} </span>
-                SYS: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[2] }} </span>
-                ENG: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[3] }} </span> ]
-              </span></div>
+            <PilotStatsBlock :pilot="pilot" />
             <div class="row flex-container-cols">
               <div class="col col-share">
                 <span>PILOT SKILL TRIGGER AUDIT</span>
@@ -140,6 +133,7 @@ import ProgressBar from '@/components/ProgressBar.vue'
 import Burden from '@/components/Burden.vue'
 
 import PilotIdentityHeader from '@/components/pilot/PilotIdentityHeader.vue'
+import PilotStatsBlock from '@/components/pilot/PilotStatsBlock.vue'
 
 export default {
   components: {
@@ -147,6 +141,7 @@ export default {
     ProgressBar,
     Typer,
     PilotIdentityHeader,
+    PilotStatsBlock,
   },
   props: {
     animate: {

--- a/src/components/pilot/PilotChipsRow.vue
+++ b/src/components/pilot/PilotChipsRow.vue
@@ -1,19 +1,12 @@
 <template>
-	<!-- TODO: this component renders one row of "chip" pills. It covers
-	     three call sites currently inlined in Pilot.vue:
-	       - lines 35-42 (PILOT SKILL TRIGGER AUDIT) — skills
-	       - lines 44-50 (PILOT TALENT AUDIT)       — talents
-	       - lines 52-60 (PROCUREMENT LICENSE AUDIT) — licenses
-	     The `kind` prop ("skill" | "talent" | "license") picks the
-	     heading text and the cci-* glyph; `items` is the array off the
-	     pilot (pilot.skills, pilot.talents, pilot.licenses).
-
-	     The label-formatting helpers (getSkill, getTalent, getLicense)
-	     in Pilot.vue methods should move into this component or into a
-	     small `pilotFormatters.js` next to assets/themes.js so both
-	     Pilot.vue and PilotModal can share them. -->
-	<div class="chip-row">
-		<span class="chip-row__heading">{{ heading }}</span>
+	<!-- One labeled chip group. Replaces three nearly-identical inline
+	     blocks in Pilot.vue (skills / talents / licenses). The wrapper
+	     <div class="col ..."> stays in Pilot.vue so the same component
+	     can sit in a half-width col-share slot (skills + talents share
+	     a row) or in a full-width col (licenses, on its own row). -->
+	<div>
+		<span>{{ heading }}</span>
+		<br>
 		<div class="chip-container" v-for="item in items" :key="item.id">
 			<span class="chip">
 				<i aria-hidden="true" class="notranslate cci" :class="`cci-${kind}`"></i>
@@ -24,6 +17,8 @@
 </template>
 
 <script>
+import lcp from "@/assets/LCPs";
+
 const HEADINGS = {
 	skill:   "PILOT SKILL TRIGGER AUDIT",
 	talent:  "PILOT TALENT AUDIT",
@@ -33,25 +28,36 @@ const HEADINGS = {
 export default {
 	name: "PilotChipsRow",
 	props: {
-		kind:  { type: String, required: true, validator: (k) => ["skill", "talent", "license"].includes(k) },
-		items: { type: Array,  required: true },
+		kind: {
+			type: String,
+			required: true,
+			validator: (k) => ["skill", "talent", "license"].includes(k),
+		},
+		items:      { type: Array,  required: true },
+		// Only used by kind="license" — appended to the heading as
+		// "PROCUREMENT LICENSE AUDIT: LEVEL X".
+		pilotLevel: { type: Number, default: 0 },
 	},
 	computed: {
-		heading() { return HEADINGS[this.kind]; },
+		heading() {
+			const base = HEADINGS[this.kind];
+			return this.kind === "license" ? `${base}: LEVEL ${this.pilotLevel}` : base;
+		},
 	},
 	methods: {
 		formatItem(item) {
-			// TODO: replace this stub with the real formatter pulled from
-			// Pilot.vue (getSkill / getTalent / getLicense). Each one
-			// needs access to the merged lcp arrays — pass them in as
-			// props or import directly from @/assets/LCPs.
-			return item.id || "";
+			if (this.kind === "skill") {
+				const sk = lcp.skills.find((x) => x.id === item.id);
+				return sk ? `${sk.name} +${item.rank * 2}` : "";
+			}
+			if (this.kind === "talent") {
+				const t = lcp.talents.find((x) => x.id === item.id);
+				return t ? `${t.name} ${"I".repeat(item.rank)}` : "";
+			}
+			// license
+			const frame = lcp.frames.find((x) => x.id === item.id);
+			return frame ? `${frame.source} ${frame.name} ${"I".repeat(item.rank)}` : "";
 		},
 	},
 };
 </script>
-
-<style scoped>
-/* TODO: move .chip-container, .chip, and chip cci-glyph styles from
-   _base.css here. */
-</style>

--- a/src/components/pilot/PilotChipsRow.vue
+++ b/src/components/pilot/PilotChipsRow.vue
@@ -1,0 +1,57 @@
+<template>
+	<!-- TODO: this component renders one row of "chip" pills. It covers
+	     three call sites currently inlined in Pilot.vue:
+	       - lines 35-42 (PILOT SKILL TRIGGER AUDIT) — skills
+	       - lines 44-50 (PILOT TALENT AUDIT)       — talents
+	       - lines 52-60 (PROCUREMENT LICENSE AUDIT) — licenses
+	     The `kind` prop ("skill" | "talent" | "license") picks the
+	     heading text and the cci-* glyph; `items` is the array off the
+	     pilot (pilot.skills, pilot.talents, pilot.licenses).
+
+	     The label-formatting helpers (getSkill, getTalent, getLicense)
+	     in Pilot.vue methods should move into this component or into a
+	     small `pilotFormatters.js` next to assets/themes.js so both
+	     Pilot.vue and PilotModal can share them. -->
+	<div class="chip-row">
+		<span class="chip-row__heading">{{ heading }}</span>
+		<div class="chip-container" v-for="item in items" :key="item.id">
+			<span class="chip">
+				<i aria-hidden="true" class="notranslate cci" :class="`cci-${kind}`"></i>
+				{{ formatItem(item) }}
+			</span>
+		</div>
+	</div>
+</template>
+
+<script>
+const HEADINGS = {
+	skill:   "PILOT SKILL TRIGGER AUDIT",
+	talent:  "PILOT TALENT AUDIT",
+	license: "PROCUREMENT LICENSE AUDIT",
+};
+
+export default {
+	name: "PilotChipsRow",
+	props: {
+		kind:  { type: String, required: true, validator: (k) => ["skill", "talent", "license"].includes(k) },
+		items: { type: Array,  required: true },
+	},
+	computed: {
+		heading() { return HEADINGS[this.kind]; },
+	},
+	methods: {
+		formatItem(item) {
+			// TODO: replace this stub with the real formatter pulled from
+			// Pilot.vue (getSkill / getTalent / getLicense). Each one
+			// needs access to the merged lcp arrays — pass them in as
+			// props or import directly from @/assets/LCPs.
+			return item.id || "";
+		},
+	},
+};
+</script>
+
+<style scoped>
+/* TODO: move .chip-container, .chip, and chip cci-glyph styles from
+   _base.css here. */
+</style>

--- a/src/components/pilot/PilotIdentityHeader.vue
+++ b/src/components/pilot/PilotIdentityHeader.vue
@@ -1,13 +1,13 @@
 <template>
-	<!-- TODO: move the .header block from Pilot.vue lines 3-9 here:
-	     - The colored bar containing the callsign + (name)
-	     - The Union faction logo on the right
-	     The bar's background should keep using var(--primary-color) and
-	     its text var(--on-primary) so it follows the active theme. -->
+	<!-- Red bar at the top of the pilot identity card: callsign,
+	     (legal name), and the Union faction logo on the right.
+	     Styling is driven by the global `.pilot-identity .header`
+	     rules in _base.css — those still match because this markup
+	     is rendered inside Pilot.vue's `.grid-item.pilot-identity`. -->
 	<div class="header">
 		<div class="col grow-max">
 			<div class="heading h1">{{ pilot.callsign }}</div>
-			<div class="heading h2">({{ pilot.name }})</div>
+			<div class="heading h2">({{ pilot.name }}) </div>
 		</div>
 		<div class="col">
 			<i class="filter-icon" style="--icon-url: url('/faction-logos/union.svg')"></i>
@@ -23,10 +23,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-/* TODO: once the split lands, move the .pilot-identity .header rules
-   (font sizes, padding, faction-logo dimensions) from _base.css into
-   this scoped block — or leave them global if they're shared with
-   PilotModal's header. */
-</style>

--- a/src/components/pilot/PilotIdentityHeader.vue
+++ b/src/components/pilot/PilotIdentityHeader.vue
@@ -1,0 +1,32 @@
+<template>
+	<!-- TODO: move the .header block from Pilot.vue lines 3-9 here:
+	     - The colored bar containing the callsign + (name)
+	     - The Union faction logo on the right
+	     The bar's background should keep using var(--primary-color) and
+	     its text var(--on-primary) so it follows the active theme. -->
+	<div class="header">
+		<div class="col grow-max">
+			<div class="heading h1">{{ pilot.callsign }}</div>
+			<div class="heading h2">({{ pilot.name }})</div>
+		</div>
+		<div class="col">
+			<i class="filter-icon" style="--icon-url: url('/faction-logos/union.svg')"></i>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: "PilotIdentityHeader",
+	props: {
+		pilot: { type: Object, required: true },
+	},
+};
+</script>
+
+<style scoped>
+/* TODO: once the split lands, move the .pilot-identity .header rules
+   (font sizes, padding, faction-logo dimensions) from _base.css into
+   this scoped block — or leave them global if they're shared with
+   PilotModal's header. */
+</style>

--- a/src/components/pilot/PilotModalButtons.vue
+++ b/src/components/pilot/PilotModalButtons.vue
@@ -1,0 +1,67 @@
+<template>
+	<!-- TODO: move the two-button block from Pilot.vue lines 72-98 here.
+	     They are the BIOMETRIC RECORD button (opens PilotModal) and the
+	     MECHANICAL BLUEPRINT button (opens MechModal). Each currently
+	     calls a method (pilotModal / mechModal) that invokes
+	     this.$oruga.modal.open(...) with the right component + props.
+
+	     Once moved, this component should EMIT events upward
+	     ("open-pilot-modal" / "open-mech-modal") and let Pilot.vue keep
+	     the $oruga calls — that keeps the modal wiring centralized and
+	     this component free of Oruga dependencies. -->
+	<div class="modal-buttons flex-container-cols">
+		<div class="row biometrics-container">
+			<button type="button" class="biometrics flex-container-cols" @click="$emit('open-pilot-modal')">
+				<div>
+					<i aria-hidden="true" class="v-icon notranslate mdi mdi-fingerprint"></i>
+				</div>
+				<div>
+					BIOMETRIC RECORD VALID [[{{ randomNumber(14, 22) }}PB]]<br />
+					OHM C//{{ timeStamp(pilot.lastModified) }}
+				</div>
+			</button>
+		</div>
+		<div class="row biometrics-container">
+			<button type="button" class="mech-record flex-container-cols" @click="$emit('open-mech-modal')">
+				<div>
+					MECHANICAL BLUEPRINT VALID [[{{ randomNumber(14, 22) }}TB]]<br />
+					{{ activeMech.manufacturer }}-{{ activeMech.frame_name }} :: "{{ activeMech.name }}"
+				</div>
+				<div>
+					<i aria-hidden="true" class="v-icon notranslate cci cci-reserve-mech larger"></i>
+				</div>
+			</button>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: "PilotModalButtons",
+	props: {
+		pilot:      { type: Object, required: true },
+		activeMech: { type: Object, required: true },
+	},
+	emits: ["open-pilot-modal", "open-mech-modal"],
+	methods: {
+		randomNumber(max, min) {
+			// TODO: lift this (and timeStamp below) into a shared utility
+			// file once the refactor lands — Pilot.vue, PilotModal.vue
+			// and MechModal all reference similar formatting helpers.
+			const rand = Math.random() * (max - min) + min;
+			return Math.floor(rand * 100) / 100;
+		},
+		timeStamp(str) {
+			const d = new Date(str);
+			d.setFullYear(d.getFullYear() + 2990);
+			return d.toISOString();
+		},
+	},
+};
+</script>
+
+<style scoped>
+/* TODO: move .biometrics, .mech-record, .biometrics-container,
+   .modal-buttons rules from _base.css here. The :hover transition
+   stays the same (background var(--highlight-hover)). */
+</style>

--- a/src/components/pilot/PilotModalButtons.vue
+++ b/src/components/pilot/PilotModalButtons.vue
@@ -1,36 +1,35 @@
 <template>
-	<!-- TODO: move the two-button block from Pilot.vue lines 72-98 here.
-	     They are the BIOMETRIC RECORD button (opens PilotModal) and the
-	     MECHANICAL BLUEPRINT button (opens MechModal). Each currently
-	     calls a method (pilotModal / mechModal) that invokes
-	     this.$oruga.modal.open(...) with the right component + props.
-
-	     Once moved, this component should EMIT events upward
-	     ("open-pilot-modal" / "open-mech-modal") and let Pilot.vue keep
-	     the $oruga calls — that keeps the modal wiring centralized and
-	     this component free of Oruga dependencies. -->
-	<div class="modal-buttons flex-container-cols">
+	<!-- BIOMETRIC RECORD and MECHANICAL BLUEPRINT buttons.
+	     Emits up rather than calling $oruga directly so the parent
+	     (Pilot.vue) keeps the modal wiring centralized and can pass
+	     the full set of props each modal needs (talents/skills/frames
+	     for PilotModal, systemsData/weaponsData for MechModal) without
+	     this component knowing about them. -->
+	<div class="flex-container-cols modal-buttons">
 		<div class="row biometrics-container">
-			<button type="button" class="biometrics flex-container-cols" @click="$emit('open-pilot-modal')">
+			<div class="biometrics flex-container-cols" @click="$emit('open-pilot-modal')">
 				<div>
-					<i aria-hidden="true" class="v-icon notranslate mdi mdi-fingerprint"></i>
+					<i aria-hidden="true" class="v-icon notranslate mdi mdi-fingerprint theme--dark grey--text text--darken-2"
+						style="font-size: 36px; margin-top:36px;"></i>
 				</div>
-				<div>
+				<div style="width:100%">
 					BIOMETRIC RECORD VALID [[{{ randomNumber(14, 22) }}PB]]<br />
 					OHM C//{{ timeStamp(pilot.lastModified) }}
 				</div>
-			</button>
+			</div>
 		</div>
 		<div class="row biometrics-container">
-			<button type="button" class="mech-record flex-container-cols" @click="$emit('open-mech-modal')">
-				<div>
-					MECHANICAL BLUEPRINT VALID [[{{ randomNumber(14, 22) }}TB]]<br />
-					{{ activeMech.manufacturer }}-{{ activeMech.frame_name }} :: "{{ activeMech.name }}"
+			<div class="mech-record flex-container-cols" @click="$emit('open-mech-modal')">
+				<div style="width:100%">
+					MECHANICAL BLUEPRINT VALID [[{{ randomNumber(14, 22) }}TB]] <br />
+					{{ activeMech.manufacturer.toUpperCase() }}-{{ activeMech.frame_name.toUpperCase() }} :: "{{ activeMech.name.toUpperCase() }}"
 				</div>
 				<div>
-					<i aria-hidden="true" class="v-icon notranslate cci cci-reserve-mech larger"></i>
+					<i aria-hidden="true"
+						class="v-icon notranslate cci cci-reserve-mech theme--dark grey--text text--darken-2 larger"
+						style="font-size: 42px; margin-top:1em;"></i>
 				</div>
-			</button>
+			</div>
 		</div>
 	</div>
 </template>
@@ -45,23 +44,43 @@ export default {
 	emits: ["open-pilot-modal", "open-mech-modal"],
 	methods: {
 		randomNumber(max, min) {
-			// TODO: lift this (and timeStamp below) into a shared utility
-			// file once the refactor lands — Pilot.vue, PilotModal.vue
-			// and MechModal all reference similar formatting helpers.
 			const rand = Math.random() * (max - min) + min;
 			return Math.floor(rand * 100) / 100;
 		},
 		timeStamp(str) {
-			const d = new Date(str);
-			d.setFullYear(d.getFullYear() + 2990);
-			return d.toISOString();
+			const date = new Date(str);
+			// Project lore offsets timestamps into the year 5000+ —
+			// bump 2990 onto whatever the real lastModified is so the
+			// rendered "OHM C//" stamp reads in-fiction.
+			return new Date(
+				date.getFullYear() + 2990,
+				date.getMonth(),
+				date.getDate(),
+				date.getHours(),
+				date.getMinutes(),
+				date.getSeconds(),
+				date.getMilliseconds()
+			).toISOString();
 		},
 	},
 };
 </script>
 
 <style scoped>
-/* TODO: move .biometrics, .mech-record, .biometrics-container,
-   .modal-buttons rules from _base.css here. The :hover transition
-   stays the same (background var(--highlight-hover)). */
+.larger::before {
+	margin-top: 9px;
+}
+
+.mdi::before {
+	margin-top: 9px;
+}
+
+.mech-record {
+	margin-left: auto;
+	text-align: right;
+}
+
+.modal-buttons {
+	margin-top: 5px;
+}
 </style>

--- a/src/components/pilot/PilotStatsBlock.vue
+++ b/src/components/pilot/PilotStatsBlock.vue
@@ -1,0 +1,35 @@
+<template>
+	<!-- TODO: move the HASE stats row from Pilot.vue lines 26-33 here.
+	     This is the
+	       FRAME CONFIGURATION OPTIONS ("H.A.S.E" OMNINET VAULT REMIT)
+	       [ HULL: X  AGI: Y  SYS: Z  ENG: W ]
+	     block. Reads pilot.mechSkills (a 4-element array indexed
+	     0..3 for HULL/AGI/SYS/ENG). -->
+	<div class="pilot-stats-block">
+		<div class="row caption">
+			FRAME CONFIGURATION OPTIONS
+			<span class="subtle--text">("H.A.S.E" OMNINET VAULT REMIT)</span>
+		</div>
+		<div class="row stats-row">
+			<span class="stat">HULL <b>{{ pilot.mechSkills[0] }}</b></span>
+			<span class="stat">AGI  <b>{{ pilot.mechSkills[1] }}</b></span>
+			<span class="stat">SYS  <b>{{ pilot.mechSkills[2] }}</b></span>
+			<span class="stat">ENG  <b>{{ pilot.mechSkills[3] }}</b></span>
+		</div>
+	</div>
+</template>
+
+<script>
+export default {
+	name: "PilotStatsBlock",
+	props: {
+		pilot: { type: Object, required: true },
+	},
+};
+</script>
+
+<style scoped>
+/* TODO: relocate the inline styles currently set on the stats spans
+   (font-size: 22px, line-height: 15px, font-size: 24px on the b) and
+   the .stat-text / .accent--text rules from _base.css. */
+</style>

--- a/src/components/pilot/PilotStatsBlock.vue
+++ b/src/components/pilot/PilotStatsBlock.vue
@@ -1,20 +1,21 @@
 <template>
-	<!-- TODO: move the HASE stats row from Pilot.vue lines 26-33 here.
-	     This is the
-	       FRAME CONFIGURATION OPTIONS ("H.A.S.E" OMNINET VAULT REMIT)
-	       [ HULL: X  AGI: Y  SYS: Z  ENG: W ]
-	     block. Reads pilot.mechSkills (a 4-element array indexed
-	     0..3 for HULL/AGI/SYS/ENG). -->
-	<div class="pilot-stats-block">
-		<div class="row caption">
+	<!-- "FRAME CONFIGURATION OPTIONS" subhead followed by the HASE
+	     stats row [ HULL: X  AGI: Y  SYS: Z  ENG: W ]. `mechSkills`
+	     is a 4-element array indexed 0..3 => HULL, AGI, SYS, ENG.
+	     Inline font-size / line-height preserve the original markup
+	     verbatim so the row's visual weight is unchanged. -->
+	<div>
+		<div style="padding-top:5px">
 			FRAME CONFIGURATION OPTIONS
 			<span class="subtle--text">("H.A.S.E" OMNINET VAULT REMIT)</span>
 		</div>
-		<div class="row stats-row">
-			<span class="stat">HULL <b>{{ pilot.mechSkills[0] }}</b></span>
-			<span class="stat">AGI  <b>{{ pilot.mechSkills[1] }}</b></span>
-			<span class="stat">SYS  <b>{{ pilot.mechSkills[2] }}</b></span>
-			<span class="stat">ENG  <b>{{ pilot.mechSkills[3] }}</b></span>
+		<div class="row" style="padding-top:5px">
+			<span style="font-size: 22px; line-height: 15px;">
+				[ HULL: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[0] }} </span>
+				AGI: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[1] }} </span>
+				SYS: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[2] }} </span>
+				ENG: <span class="stat-text accent--text" style="font-size: 24px;"> {{ pilot.mechSkills[3] }} </span> ]
+			</span>
 		</div>
 	</div>
 </template>
@@ -27,9 +28,3 @@ export default {
 	},
 };
 </script>
-
-<style scoped>
-/* TODO: relocate the inline styles currently set on the stats spans
-   (font-size: 22px, line-height: 15px, font-size: 24px on the b) and
-   the .stat-text / .accent--text rules from _base.css. */
-</style>


### PR DESCRIPTION
## Summary

Refactors the 376-line `Pilot.vue` into a parent shell plus four single-responsibility children under `src/components/pilot/`. No visual or behavioral change — every commit produces a UI identical to the previous one. The three duplicated chip blocks (skills / talents / licenses) collapse into one shared component, dead imports and orphaned methods are removed, and `Pilot.vue` drops to 180 lines.

## What moves where

| From `Pilot.vue` | To |
|---|---|
| `.header` block (callsign + name + Union logo) | `PilotIdentityHeader.vue` |
| `FRAME CONFIGURATION OPTIONS` + HASE stats row | `PilotStatsBlock.vue` |
| Three near-identical chip lists (skills / talents / licenses) | `PilotChipsRow.vue` invoked three times with `kind="skill"|"talent"|"license"` |
| `BIOMETRIC RECORD` + `MECHANICAL BLUEPRINT` buttons + their `randomNumber` / `timeStamp` helpers | `PilotModalButtons.vue` |

Modal wiring (`$oruga.modal.open(...)` with `PilotModal` / `MechModal`) stays in `Pilot.vue`. `PilotModalButtons` emits `open-pilot-modal` / `open-mech-modal` upward so the parent keeps the modal contract centralized.

## Commit-by-commit

| Commit | Change |
|---|---|
| `db05608` | Cherry-pick scaffolds (empty shells with TODOs from the earlier scoping branch) |
| `752baaa` | Plug in `<PilotIdentityHeader>` |
| `3a9499c` | Plug in `<PilotStatsBlock>` |
| `7484bb8` | Plug in `<PilotChipsRow>` — three duplicated blocks become one component used three times |
| `66a543a` | Plug in `<PilotModalButtons>` with emitted events upward |
| `f342cdb` | Drop dead code: unused imports (`Burden`, `ProgressBar`, `Typer`, `external-svg-loader`), orphaned computed (`pilotCode`, `pilotInfo`, `mechManufacturerIcon`, `mechPortrait`, `pilotGear`, `bonds`), unreachable methods (`getBond`, `getHistory`), unused `data.bond` |

## Why this isn't shipped as one commit

Each commit individually passes `npm run build` and keeps the pilot card rendering correctly. If a visual regression is introduced anywhere, `git bisect` lands on the exact piece (header vs stats vs chips vs buttons) instead of a single 400-line diff.

## Metrics

- `Pilot.vue`: 376 → **180 lines** (-52%)
- Sub-components: 204 lines total across 4 files
- 5 unused imports removed
- 5 dead computed removed
- 2 dead methods removed
- 3 duplicated chip blocks → 1 reusable component

## Test plan

- [x] Open `/pilots`, confirm the red header bar, HASE stats row, skill / talent / license chip lists, and pilot portrait all render identically to `main`
- [x] Click the `BIOMETRIC RECORD` tile → `PilotModal` opens with the pilot's data
- [x] Click the `MECHANICAL BLUEPRINT` tile → `MechModal` opens with the active mech
- [x] Switch themes in Settings: the header bar / stats row / chips all recolor with the new `--primary-color`
- [x] Mobile and tablet breakpoints still wrap correctly (responsive CSS is unchanged but worth a smoke test)
