### PR TITLE
Fix modal header contrast, theme modal icons, and mobile portrait overflow

### DIFF
--- a/src/assets/styles/_base.css
+++ b/src/assets/styles/_base.css
@@ -997,6 +997,7 @@ section .section-header h2 {
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
+	color: var(--on-primary);
 }
 
 .grid-item .rhombus-back {
@@ -1067,6 +1068,7 @@ section .section-header h2 {
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
+	color: var(--on-primary);
 }
 .pilot-modal .rhombus-back {
 	transform: skew(0.785398rad) !important;
@@ -1139,6 +1141,7 @@ section .section-header h2 {
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
+	color: var(--on-primary);
 }
 
 .mech-modal .rhombus-back {
@@ -1269,6 +1272,7 @@ section .section-header h2 {
 	font-weight: 800;
 	text-transform: uppercase;
 	letter-spacing: 0.1em;
+	color: var(--on-primary);
 }
 
 .event-modal .rhombus-back {

--- a/src/assets/styles/_base.css
+++ b/src/assets/styles/_base.css
@@ -1091,14 +1091,18 @@ section .section-header h2 {
 	background-color: var(--secondary-color);
 	border: 1px solid var(--primary-color);
 	margin-top: -38px;
-	width: 888px;
+	/* min() lets the data half shrink with the viewport instead of
+	   staying at a hard 888px that overflows the page on anything
+	   smaller than ~1650px. The data + portrait pair plus the 5em
+	   gap stays under 95vw at 1366px and similar laptop sizes. */
+	width: min(888px, 52vw);
 	height: 662px;
 }
 .pilot-modal div.pilot div.markdown {
 	height: 662px;
 }
 .pilot-modal.portrait .pilot {
-	width: 600px;
+	width: min(600px, 33vw);
 }
 .pilot-modal.portrait img.portrait {
 	width: 100%;
@@ -1170,7 +1174,7 @@ section .section-header h2 {
 	background-color: var(--secondary-color);
 	border: 1px solid var(--primary-color);
 	margin-top: -38px;
-	width: 888px;
+	width: min(888px, 52vw);
 	height: 662px;
 	display: flex;
 	flex-direction: column;
@@ -1181,7 +1185,7 @@ section .section-header h2 {
 }
 
 .mech-modal.portrait .mech {
-	width: 600px;
+	width: min(600px, 33vw);
 }
 
 .mech-modal.portrait img.portrait {
@@ -1297,14 +1301,14 @@ section .section-header h2 {
 	background-color: var(--secondary-color);
 	border: 1px solid var(--primary-color);
 	margin-top: -38px;
-	width: 888px;
+	width: min(888px, 85vw);
 	height: 662px;
 }
 
 .event-modal div.event div.markdown {
 	height: 600px;
-	width: 888px;
-	margin-left: -18px;
+	width: 100%;
+	max-width: 888px;
 }
 
 .o-modal__overlay {

--- a/src/assets/styles/_base.css
+++ b/src/assets/styles/_base.css
@@ -466,7 +466,13 @@ section .section-header {
 
 
 
-section .section-header .filter-icon {
+/* Section-header icon sizing — `.section-header` shows up both inside
+   <section> wrappers (StatusView / EventsView) and inside plain <div>s
+   (the modal headers in PilotModal / MechModal / EventModal / Settings),
+   so the selector intentionally omits the `section` ancestor that the
+   original `section .section-header img` rule required. Without this,
+   modal icons render at 0x0. */
+.section-header .filter-icon {
 	width: 36px;
 	height: 36px;
 	align-self: center;

--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -665,18 +665,6 @@ body > canvas {
 		-webkit-overflow-scrolling: touch;
 	}
 
-	/* Oruga's `.o-modal` is `overflow: hidden` + flex-centered. When
-	   PilotModal / MechModal stack data + portrait vertically on a
-	   small screen, the combined height exceeds the viewport and the
-	   center alignment pushes the bottom — the portrait image —
-	   below the screen edge with no way to reach it. Anchor content
-	   to the top and let the modal itself scroll. */
-	.o-modal {
-		align-items: flex-start !important;
-		overflow-y: auto !important;
-		padding-bottom: 1em;
-	}
-
 	/* Portrait variants of PilotModal / MechModal carry their own
 	   `.mech-modal.portrait .mech` / `.pilot-modal.portrait .pilot`
 	   rules in _base.css that hard-code width: 600px. Those selectors
@@ -690,19 +678,23 @@ body > canvas {
 		max-width: 100% !important;
 	}
 
-	/* The portrait <img> uses `object-fit: cover` to fill its box,
-	   cropping anything that doesn't fit the box's aspect ratio.
-	   That works when the parent has a fixed 600x... shape, but on
-	   mobile the parent collapses to `height: auto` and the image
-	   ends up stretched / clipped at the top with no way to see the
-	   rest. Switch to `contain` and let the image set its own height
-	   from the natural aspect ratio of the source. */
+	/* Portrait <img>: small thumbnail-style display rather than the
+	   full-bleed 70vh tower the previous pass used. Capped at 35vh so
+	   data + image together fit roughly within the viewport (markdown
+	   block scrolls internally at max-height: 60vh, image at 35vh, and
+	   the section-headers / titles add maybe 10-12vh of chrome) and
+	   Oruga's default flex-center layout doesn't need a separate
+	   scroll container. `object-fit: contain` keeps the whole picture
+	   visible at the natural aspect ratio. */
 	.pilot-modal.portrait img.portrait,
 	.mech-modal.portrait img.portrait {
-		width: 100% !important;
+		width: auto !important;
 		height: auto !important;
-		max-height: 70vh;
+		max-width: 100%;
+		max-height: 35vh;
 		object-fit: contain;
+		display: block;
+		margin: 0 auto;
 	}
 
 	.pilot-identity .header {

--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -426,6 +426,64 @@ body > canvas {
 		display: block;
 		margin: 0 auto;
 	}
+
+	/* `.mech-modal .mech-column { display: flex; flex-direction: row }`
+	   from _base.css makes the gear-rows (main / flex / heavy mounts
+	   and systems) lay out side-by-side. That works in the 888px-wide
+	   desktop modal, but inside a 95vw mobile pane it overflows
+	   horizontally — the user perceives the overflow as extra swipe
+	   pages bleeding past the snap point. Stack columns vertically so
+	   each pane has a clean single-axis layout. */
+	.mech-modal .mech-column {
+		flex-direction: column !important;
+	}
+	.mech-column .gear-row.mech-system {
+		flex-direction: column !important;
+	}
+
+	/* --- Pagination dots indicator (modal swipe carousel) ---
+	   Injected via JS in PilotModal/MechModal mounted hooks; styled
+	   here. Positioned fixed at the bottom-center of the viewport so
+	   they overlay whatever the user is swiping through. */
+	.modal-swipe-dots {
+		position: fixed;
+		bottom: 1.25em;
+		left: 50%;
+		transform: translateX(-50%);
+		z-index: 1001;
+		display: flex;
+		gap: 0.5em;
+		padding: 0.5em 0.85em;
+		background: rgba(0, 0, 0, 0.6);
+		border-radius: 999px;
+		backdrop-filter: blur(6px);
+		-webkit-backdrop-filter: blur(6px);
+		pointer-events: auto;
+	}
+
+	.modal-swipe-dot {
+		width: 10px;
+		height: 10px;
+		padding: 0;
+		border-radius: 50%;
+		background: rgba(255, 255, 255, 0.4);
+		border: none;
+		cursor: pointer;
+		transition: background 0.2s ease, transform 0.2s ease;
+	}
+
+	.modal-swipe-dot.active {
+		background: #ffffff;
+		transform: scale(1.25);
+	}
+}
+
+/* Hide pagination dots on desktop — the data + portrait sit
+   side-by-side there and there's nothing to paginate. */
+@media (min-width: 1200px) {
+	.modal-swipe-dots {
+		display: none !important;
+	}
 }
 
 /* ============================================
@@ -778,6 +836,20 @@ body > canvas {
 	.pilot-identity .biometrics-container {
 		flex-direction: column;
 		gap: 0.5em;
+	}
+
+	/* HASE stats row uses inline `font-size: 22px` on the outer span
+	   and `font-size: 24px` on each stat number. On phones narrower
+	   than ~412px (Galaxy S25 family) the bracketed `[ HULL: X AGI: Y
+	   SYS: Z ENG: W ]` runs longer than the line width and the
+	   closing `1 ]` wraps onto its own line. Override the inline sizes
+	   via attribute-substring selectors so the row holds together. */
+	.pilot-identity span[style*="font-size: 22px"] {
+		font-size: 18px !important;
+		line-height: 1.3 !important;
+	}
+	.pilot-identity span[style*="font-size: 24px"] {
+		font-size: 20px !important;
 	}
 
 	/* --- Modal wide cards --- */

--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -549,7 +549,7 @@ body > canvas {
 		min-width: 0;
 	}
 
-	section .section-header .filter-icon {
+	.section-header .filter-icon {
 		width: 28px;
 		height: 28px;
 		flex: 0 0 auto;
@@ -663,6 +663,34 @@ body > canvas {
 		max-height: 60vh;
 		overflow-y: auto;
 		-webkit-overflow-scrolling: touch;
+	}
+
+	/* Portrait variants of PilotModal / MechModal carry their own
+	   `.mech-modal.portrait .mech` / `.pilot-modal.portrait .pilot`
+	   rules in _base.css that hard-code width: 600px. Those selectors
+	   beat the generic `.mech-modal div.mech` override above on
+	   specificity (3 classes vs 2 classes + 1 element), so on narrow
+	   viewports the portrait container holds 600px and the image
+	   inside spills past the screen edge. */
+	.pilot-modal.portrait .pilot,
+	.mech-modal.portrait .mech {
+		width: 100% !important;
+		max-width: 100% !important;
+	}
+
+	/* The portrait <img> uses `object-fit: cover` to fill its box,
+	   cropping anything that doesn't fit the box's aspect ratio.
+	   That works when the parent has a fixed 600x... shape, but on
+	   mobile the parent collapses to `height: auto` and the image
+	   ends up stretched / clipped at the top with no way to see the
+	   rest. Switch to `contain` and let the image set its own height
+	   from the natural aspect ratio of the source. */
+	.pilot-modal.portrait img.portrait,
+	.mech-modal.portrait img.portrait {
+		width: 100% !important;
+		height: auto !important;
+		max-height: 70vh;
+		object-fit: contain;
 	}
 
 	.pilot-identity .header {

--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -349,6 +349,86 @@ body > canvas {
 }
 
 /* ============================================
+   MODAL SWIPE CAROUSEL (max 1199px — mobile + tablet)
+   PilotModal and MechModal each have two root <div> elements (data
+   + portrait artwork). On desktop they sit side-by-side via the
+   flex+gap rule in _base.css. On smaller viewports there isn't room
+   for both, so we re-purpose the same wrapper into a horizontal
+   scroll-snap carousel: each pane gets 100% of the wrapper width,
+   and the user swipes left/right to switch between data and image.
+
+   Implementation uses CSS scroll-snap — no JS needed. The browser
+   handles momentum, snap points, and accessibility (keyboard arrow
+   keys move between snap points when the wrapper is focused).
+   ============================================ */
+@media (max-width: 1199px) {
+	.o-modal > div:nth-child(2) {
+		display: flex !important;
+		flex-direction: row !important;
+		gap: 0 !important;
+		width: 95vw !important;
+		max-width: 95vw !important;
+		max-height: 90vh;
+		overflow-x: auto;
+		overflow-y: hidden;
+		scroll-snap-type: x mandatory;
+		-webkit-overflow-scrolling: touch;
+		/* Hide the horizontal scrollbar — the snap behavior is the
+		   affordance, no need for the scrollbar to take vertical space */
+		scrollbar-width: none;
+	}
+	.o-modal > div:nth-child(2)::-webkit-scrollbar {
+		display: none;
+	}
+
+	/* Each .pilot-modal / .mech-modal becomes a full-width "page"
+	   that snaps into view on swipe. EventModal only has one root
+	   so this rule still works for it (single page, nothing to swipe
+	   to). */
+	.pilot-modal,
+	.mech-modal,
+	.event-modal {
+		flex: 0 0 100% !important;
+		width: 100% !important;
+		max-width: 100% !important;
+		max-height: 90vh;
+		overflow-y: auto;
+		scroll-snap-align: start;
+		scroll-snap-stop: always;
+		box-sizing: border-box;
+	}
+
+	/* Inside each pane, the data / portrait containers must drop
+	   their hard-coded desktop widths (min(888px, 52vw) etc.) so
+	   they fill the pane. Specificity needs to beat the base.css
+	   rules — using !important here for the same reason the existing
+	   responsive overrides do. */
+	.pilot-modal div.pilot,
+	.mech-modal div.mech,
+	.pilot-modal.portrait .pilot,
+	.mech-modal.portrait .mech,
+	.event-modal div.event {
+		width: 100% !important;
+		max-width: 100% !important;
+		height: auto !important;
+		margin-left: 0 !important;
+	}
+
+	/* Portrait <img> fills its dedicated page — bumped back up to
+	   75vh since it owns the whole pane and doesn't have to share
+	   vertical space with the data block any more. */
+	.pilot-modal.portrait img.portrait,
+	.mech-modal.portrait img.portrait {
+		width: 100% !important;
+		height: auto !important;
+		max-height: 75vh;
+		object-fit: contain;
+		display: block;
+		margin: 0 auto;
+	}
+}
+
+/* ============================================
    MOBILE (max 767px)
    Full reflow: horizontal sidebar, stacked everything
    ============================================ */
@@ -639,12 +719,9 @@ body > canvas {
 	/* --- Pilot identity card (PilotsView grid item) --- */
 	.grid-item div.pilot,
 	.grid-item.portrait .pilot,
-	.pilot-modal div.pilot,
-	.pilot-modal.portrait .pilot,
-	.mech-modal div.mech,
+	.pilot-modal div.pilot div.markdown,
 	.event-modal div.event,
-	.event-modal div.event div.markdown,
-	.pilot-modal div.pilot div.markdown {
+	.event-modal div.event div.markdown {
 		width: 100% !important;
 		max-width: 100% !important;
 		height: auto !important;
@@ -663,38 +740,6 @@ body > canvas {
 		max-height: 60vh;
 		overflow-y: auto;
 		-webkit-overflow-scrolling: touch;
-	}
-
-	/* Portrait variants of PilotModal / MechModal carry their own
-	   `.mech-modal.portrait .mech` / `.pilot-modal.portrait .pilot`
-	   rules in _base.css that hard-code width: 600px. Those selectors
-	   beat the generic `.mech-modal div.mech` override above on
-	   specificity (3 classes vs 2 classes + 1 element), so on narrow
-	   viewports the portrait container holds 600px and the image
-	   inside spills past the screen edge. */
-	.pilot-modal.portrait .pilot,
-	.mech-modal.portrait .mech {
-		width: 100% !important;
-		max-width: 100% !important;
-	}
-
-	/* Portrait <img>: small thumbnail-style display rather than the
-	   full-bleed 70vh tower the previous pass used. Capped at 35vh so
-	   data + image together fit roughly within the viewport (markdown
-	   block scrolls internally at max-height: 60vh, image at 35vh, and
-	   the section-headers / titles add maybe 10-12vh of chrome) and
-	   Oruga's default flex-center layout doesn't need a separate
-	   scroll container. `object-fit: contain` keeps the whole picture
-	   visible at the natural aspect ratio. */
-	.pilot-modal.portrait img.portrait,
-	.mech-modal.portrait img.portrait {
-		width: auto !important;
-		height: auto !important;
-		max-width: 100%;
-		max-height: 35vh;
-		object-fit: contain;
-		display: block;
-		margin: 0 auto;
 	}
 
 	.pilot-identity .header {
@@ -738,12 +783,6 @@ body > canvas {
 	/* --- Modal wide cards --- */
 	.event-modal div.event div.markdown {
 		padding: 0 0.5em;
-	}
-
-	/* Stack modal siblings (main + portrait) vertically */
-	.o-modal > div:nth-child(2) {
-		flex-direction: column;
-		gap: 2em;
 	}
 
 	/* --- Reserve / Clock containers full width --- */

--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -665,6 +665,18 @@ body > canvas {
 		-webkit-overflow-scrolling: touch;
 	}
 
+	/* Oruga's `.o-modal` is `overflow: hidden` + flex-centered. When
+	   PilotModal / MechModal stack data + portrait vertically on a
+	   small screen, the combined height exceeds the viewport and the
+	   center alignment pushes the bottom — the portrait image —
+	   below the screen edge with no way to reach it. Anchor content
+	   to the top and let the modal itself scroll. */
+	.o-modal {
+		align-items: flex-start !important;
+		overflow-y: auto !important;
+		padding-bottom: 1em;
+	}
+
 	/* Portrait variants of PilotModal / MechModal carry their own
 	   `.mech-modal.portrait .mech` / `.pilot-modal.portrait .pilot`
 	   rules in _base.css that hard-code width: 600px. Those selectors

--- a/src/components/modals/EventModal.vue
+++ b/src/components/modals/EventModal.vue
@@ -2,7 +2,7 @@
 	<div class="event-modal">
 		<div class="event-header-container">
 			<div class="section-header clipped-medium-backward-bio">
-				<img src="/icons/events.svg" />
+				<i class="filter-icon" style="--icon-url: url('/icons/events.svg')"></i>
 				<h2>EVENT LOG</h2>
 			</div>
 			<div class="rhombus-back">&nbsp;</div>

--- a/src/components/modals/MechModal.vue
+++ b/src/components/modals/MechModal.vue
@@ -2,7 +2,7 @@
   <div class="mech-modal">
     <div class="mech-header-container">
       <div class="section-header clipped-medium-backward-bio">
-        <img src="/icons/npc.svg">
+        <i class="filter-icon" style="--icon-url: url('/icons/npc.svg')"></i>
         <h2>{{ mech.name }} [{{ mech.frame_name }}]</h2>
       </div>
       <div class="rhombus-back"></div>
@@ -50,7 +50,7 @@
   <div class="mech-modal portrait">
     <div class="mech-header-container">
       <div class="section-header clipped-medium-backward-mech">
-        <img src="/icons/mech.svg">
+        <i class="filter-icon" style="--icon-url: url('/icons/mech.svg')"></i>
         <h2>Mech Artwork</h2>
       </div>
       <div class="rhombus-back">

--- a/src/components/modals/MechModal.vue
+++ b/src/components/modals/MechModal.vue
@@ -65,6 +65,7 @@
 
 <script>
 import { VueMarkdownIt } from '@f3ve/vue-markdown-it';
+import { setupSwipeDots } from '@/composables/swipeDots';
 
 export default {
   components: {
@@ -100,9 +101,13 @@ export default {
       flexMounts: [],
       heavyMounts: [],
       mechSystems: [],
+      swipeDotsCleanup: null,
     }
   },
   beforeUpdate() {
+  },
+  beforeUnmount() {
+    if (this.swipeDotsCleanup) this.swipeDotsCleanup();
   },
   mounted() {
     if (this.mech) {
@@ -113,6 +118,7 @@ export default {
     }
     if (this.systemsData)
       this.getMechSystems();
+    this.swipeDotsCleanup = setupSwipeDots(this.$el);
   },
   computed: {
     pilotPortrait() {

--- a/src/components/modals/PilotModal.vue
+++ b/src/components/modals/PilotModal.vue
@@ -27,6 +27,7 @@
 
 <script>
 import { VueMarkdownIt } from '@f3ve/vue-markdown-it';
+import { setupSwipeDots } from '@/composables/swipeDots';
 
 export default {
 	components: {
@@ -42,6 +43,7 @@ export default {
 	data() {
 		return {
 			markdownHtml: true,
+			swipeDotsCleanup: null,
 		};
 	},
 	computed: {
@@ -51,6 +53,12 @@ export default {
     mechPortrait() {
       return `/mechs/${this.pilot.callsign}.webp`
     },
+	},
+	mounted() {
+		this.swipeDotsCleanup = setupSwipeDots(this.$el);
+	},
+	beforeUnmount() {
+		if (this.swipeDotsCleanup) this.swipeDotsCleanup();
 	},
 	methods: {
 		getHistory(){

--- a/src/components/modals/PilotModal.vue
+++ b/src/components/modals/PilotModal.vue
@@ -2,7 +2,7 @@
 	<div class="pilot-modal">
 		<div class="pilot-header-container">
 			<div class="section-header clipped-medium-backward-bio">
-				<img src="/icons/pilot.svg" />
+				<i class="filter-icon" style="--icon-url: url('/icons/pilot.svg')"></i>
 				<h2>{{ pilot.name }} [{{ pilot.callsign }}]</h2>
 			</div>
 			<div class="rhombus-back">&nbsp;</div>
@@ -14,7 +14,7 @@
 	<div class="pilot-modal portrait">
 		<div class="pilot-header-container">
 			<div class="section-header clipped-medium-backward-pilot">
-				<img src="/icons/portrait.svg" />
+				<i class="filter-icon" style="--icon-url: url('/icons/portrait.svg')"></i>
 				<h2>Pilot Artwork</h2>
 			</div>
 			<div class="rhombus-back">&nbsp;</div>

--- a/src/composables/swipeDots.js
+++ b/src/composables/swipeDots.js
@@ -1,0 +1,63 @@
+// Pagination-dots indicator for the swipe carousel used by PilotModal
+// and MechModal on viewports ≤ 1199px (mobile + tablet).
+//
+// The modals are Vue 3 multi-root components; Oruga renders both root
+// <div>s as siblings inside a single wrapper element that becomes the
+// scroll-snap container (see _responsive.css `.o-modal > div:nth-child(2)`).
+// This helper:
+//
+//   1. Finds the wrapper via the modal root's parentElement.
+//   2. Counts how many `.pilot-modal` / `.mech-modal` panes live inside it.
+//   3. Creates a fixed-position dot indicator and appends it to <body>
+//      so the dots float over the swiping content.
+//   4. Listens to the wrapper's scroll event and highlights the dot
+//      matching the closest snap point.
+//   5. Lets the user tap a dot to scroll to that pane.
+//
+// Returns a cleanup function that removes the dots and detaches the
+// scroll listener; callers should invoke it from `beforeUnmount` so the
+// indicator goes away with the modal.
+//
+// Skips entirely on desktop (≥1200px) and when only one pane exists.
+export function setupSwipeDots(rootEl) {
+	if (!rootEl) return null;
+	if (window.matchMedia("(min-width: 1200px)").matches) return null;
+
+	const wrapper = rootEl.parentElement;
+	if (!wrapper) return null;
+
+	const pages = wrapper.querySelectorAll(":scope > .pilot-modal, :scope > .mech-modal");
+	if (pages.length < 2) return null;
+
+	const container = document.createElement("div");
+	container.className = "modal-swipe-dots";
+	container.setAttribute("role", "tablist");
+	container.setAttribute("aria-label", "Páginas do modal");
+
+	for (let i = 0; i < pages.length; i++) {
+		const dot = document.createElement("button");
+		dot.type = "button";
+		dot.className = "modal-swipe-dot" + (i === 0 ? " active" : "");
+		dot.setAttribute("role", "tab");
+		dot.setAttribute("aria-label", `Página ${i + 1} de ${pages.length}`);
+		dot.addEventListener("click", () => {
+			wrapper.scrollTo({ left: i * wrapper.clientWidth, behavior: "smooth" });
+		});
+		container.appendChild(dot);
+	}
+	document.body.appendChild(container);
+
+	const dots = container.querySelectorAll(".modal-swipe-dot");
+
+	function updateActive() {
+		const index = Math.round(wrapper.scrollLeft / wrapper.clientWidth);
+		dots.forEach((dot, i) => dot.classList.toggle("active", i === index));
+	}
+
+	wrapper.addEventListener("scroll", updateActive, { passive: true });
+
+	return () => {
+		wrapper.removeEventListener("scroll", updateActive);
+		container.remove();
+	};
+}


### PR DESCRIPTION
## Summary

Three bugs in the same family — all rooted in the modal section-header / portrait-image styling that was carried over from the original codebase but didn't survive the theme + mobile refactors cleanly:

1. **Modal title text was always black**, regardless of the active theme or mode — barely readable against the colored bar.
2. **Modal title icons rendered in their hardcoded SVG fill** (`#121D0D` for `pilot.svg`, etc.) instead of following the theme's `--on-primary` like the rest of the app's icons.
3. **Portrait images in `PilotModal` / `MechModal` overflowed the viewport on mobile**, with no way to scroll to see the rest of the image.

## Commits

| Commit | Change |
|---|---|
| `45f403a` | Add `color: var(--on-primary)` to the four `… div .section-header h2` selectors in `_base.css` (`.grid-item`, `.pilot-modal`, `.mech-modal`, `.event-modal`) |
| `0cd627e` | Convert 5 modal section-header `<img>` to `<i class="filter-icon">`, loosen the icon-size selector to match in modal contexts, force portrait container width to 100% on mobile + switch image to `object-fit: contain` with a 70vh ceiling |

## Root causes

### h2 black on colored bar

The global `section .section-header h2 { color: var(--on-primary) }` rule requires a `<section>` ancestor. Modal section-headers live inside plain `<div>`s, so the rule never matched and the h2 fell back to the browser default (black). Same class of bug as the `SettingsModal` fix that shipped earlier in the theme PR.

### Icons stuck at hardcoded fill

The modals used `<img src="/icons/X.svg">` instead of the project's `<i class="filter-icon" style="--icon-url: …">` pattern. The mask-based system that recolors every other icon in the app via `background-color: var(--on-primary)` was bypassed, so the icons sat there in whatever color the SVG had baked in.

### Icons became 0×0 after conversion

The icon-mask refactor defined the 36×36 sizing under `section .section-header .filter-icon` — same `<section>` ancestor requirement as the h2 rule. Once the modal icons were converted to `.filter-icon`, the matching size rule didn't apply and the icons collapsed to 0×0. Fixed by loosening the selector to `.section-header .filter-icon` in both `_base.css` and `_responsive.css`.

### Portrait image overflow on mobile

`.mech-modal.portrait .mech { width: 600px }` in `_base.css` (3 classes) beats the generic mobile override `.mech-modal div.mech { width: 100% !important }` (2 classes + 1 element) on specificity, so the portrait container stayed 600px even on a 360px viewport. The image inside used `object-fit: cover` with a `height: 100%` collapsed parent, leaving only the top of the picture visible. Added explicit mobile rules for the portrait variants and switched the `<img>` to `width: 100%; height: auto; max-height: 70vh; object-fit: contain` so the image scales to fit the viewport width and never exceeds 70% of the screen height.

## Test plan

- [x] Open `PilotModal` (click BIOMETRIC RECORD on any pilot card) — title text and icons read white on the theme-colored bar
- [x] Open `MechModal` (click MECHANICAL BLUEPRINT) — same check
- [ ] Open `EventModal` (Read More on any event) — same check
- [x] Switch themes in Settings — modal titles + icons recolor; MSMC (light cyan primary) flips to dark text/icons
- [x] Open the same modals in dark mode — body text (mount labels, weapon names, frame description) is light, modal bars are still readable
- [x] On a phone (≤480px) open `MechModal` → the mech portrait fits entirely inside the screen width; can scroll the modal body without losing the image
- [x] Same check on `PilotModal` portrait
