### PR TITLE
Move mobile hamburger to bottom-left FAB, free header space, more bot…

### DIFF
--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -48,21 +48,21 @@ body > canvas {
 .sidebar-toggle {
 	display: none;
 	position: fixed;
-	top: 12px;
-	right: 12px;
+	bottom: 16px;
+	left: 16px;
 	z-index: 1001;
 	width: 44px;
 	height: 44px;
 	padding: 0;
 	background: var(--primary-color);
 	border: none;
-	border-radius: 4px;
+	border-radius: 50%;
 	cursor: pointer;
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
 	gap: 5px;
-	box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
 }
 
 .sidebar-toggle span {
@@ -586,6 +586,13 @@ body > canvas {
 		display: flex;
 	}
 
+	/* Hide the floating hamburger while any Oruga modal is open so it
+	   doesn't compete for attention with the modal content (or sit on
+	   top of the swipe carousel's pagination dots). */
+	body:has(.o-modal) .sidebar-toggle {
+		display: none;
+	}
+
 	.sidebar-overlay {
 		display: block;
 	}
@@ -643,7 +650,10 @@ body > canvas {
 		top: auto;
 		left: auto;
 		margin: 0;
-		padding: 0 8px 2em 8px;
+		/* Extra bottom padding so the hamburger FAB at bottom-left
+		   (44px + 16px gap = ~60px tall) doesn't sit on top of the
+		   last item when the user scrolls all the way down. */
+		padding: 0 8px 5em 8px;
 		width: 100%;
 		box-sizing: border-box;
 	}


### PR DESCRIPTION
Hamburger toggle used to live at top:12 / right:12, overlapping the right end of the planet/location info in the stacked mobile header. On a narrow screen the button covered useful header text and was the first thing the user collided with when they tapped near a corner.

Moved it to bottom-left (a more conventional FAB anchor) and switched the shape to a circle so it reads as a floating action button:

  position: fixed; bottom: 16px; left: 16px;
  border-radius: 50%;
  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);

Two adjacent tweaks for the new position:

- Bumped `#router-view-container` bottom padding from 2em to 5em on mobile so the last item in any scrollable list doesn't end up underneath the FAB once the user scrolls all the way down.
- Added `body:has(.o-modal) .sidebar-toggle { display: none }` so the FAB hides while an Oruga modal is open — keeps it from sitting on top of the PilotModal / MechModal swipe pagination dots and from competing for attention with whatever the user is reading in the modal.

The drawer itself still slides in from the left (220px wide) — the FAB at bottom-left ends up overlaying the drawer's bottom-left corner when open, so the user can keep tapping the same spot to close it.