### PR TITLE
Center pilot card on small phones (Galaxy S25 family)

### DIFF
--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -929,4 +929,40 @@ body > canvas {
 		width: 140px;
 		height: 140px;
 	}
+
+	/* On Galaxy S25-class phones (~360-400px viewports) the pilot
+	   card was sitting a few pixels right of center, hiding its right
+	   border behind the viewport edge. Two compounding causes:
+
+	   1. The IDENT record line "Hunt.Caleb:<UUID>//NDL-C-BLIND-REACH"
+	      is one ~67-character token in monospace with no spaces. CSS
+	      defaults to `word-break: normal`, which doesn't break inside
+	      tokens, so the line overflowed its container horizontally
+	      and pushed the entire card content past the viewport.
+	   2. `.grid-item { flex: 45% }` in PilotsView's scoped CSS leaves
+	      the card flex-growable from a 45% basis. With one item it
+	      grows to fill, but combined with #1 the grow target landed
+	      slightly wider than the available width.
+
+	   Forcing `flex: 0 0 100%` pins the card to exactly the
+	   container's inner width, and allowing the long IDENT token to
+	   break anywhere prevents the overflow that triggered the
+	   shift. The .pilot-list-container also drops to 0.5em side
+	   padding to give the card a little more breathing room on the
+	   narrowest devices. */
+	.pilot-list-container {
+		padding: 0.5em !important;
+		justify-content: center;
+	}
+	.grid-item.pilot-identity {
+		flex: 0 0 100% !important;
+		max-width: 100% !important;
+		min-width: 0;
+		margin: 0;
+		box-sizing: border-box;
+	}
+	.pilot-identity .body {
+		overflow-wrap: anywhere;
+		word-break: break-word;
+	}
 }


### PR DESCRIPTION
## Summary

On ~360-400px viewports (Galaxy S25 class) the pilot identity card sat a few pixels right of viewport center — the right border clipped behind the screen edge while a transparent gap of similar width sat on the left.

## Root causes

1. **IDENT record line overflow.** Every pilot card opens with \`Hunt.Caleb:<UUID>//NDL-C-BLIND-REACH\` — a ~67-character monospace token with no whitespace. CSS defaults to \`word-break: normal\`, which never breaks inside tokens, so the line overflowed its container horizontally. \`#app { overflow: hidden }\` clipped the overflow itself, but its presence still skewed the flex layout that decided the card's final box.
2. **Flex basis at 45% with grow.** PilotsView's scoped \`.grid-item { flex: 45% }\` leaves the card flex-growable from a 45% starting basis. With one item it grows to fill available space, but combined with #1 the calculated grow target landed slightly wider than the actual viewport allowance and the card ended up offset.

## Fix

Inside \`@media (max-width: 480px)\`:

\`\`\`css
.pilot-list-container       { padding: 0.5em; justify-content: center; }
.grid-item.pilot-identity   { flex: 0 0 100%; max-width: 100%; }
.pilot-identity .body       { overflow-wrap: anywhere; word-break: break-word; }
\`\`\`

- \`flex: 0 0 100%\` pins the card to exactly the container's inner width so no flex-grow math can drift it.
- \`overflow-wrap: anywhere\` + \`word-break: break-word\` lets the long IDENT token wrap inside the card body instead of spilling past it.
- Dropping \`.pilot-list-container\` padding from \`1em\` to \`0.5em\` returns ~16px of horizontal breathing room to the card on the narrowest devices.

## Test plan

- [x] On a ~360-400px viewport (Galaxy S25, iPhone 13 mini, etc.) open \`/pilots\` — pilot card is centered with equal transparent gap on both sides, both red borders visible
- [x] The \"Hunt.Caleb:UUID//NDL-C-BLIND-REACH\" line wraps inside the card instead of overflowing
- [x] At ≥481px the desktop / tablet layout is unchanged (rule lives inside the small-mobile media query)