### PR TITLE
Add In Golden Flame Act 1 (igfa1) LCP

### DIFF
--- a/src/assets/LCPs/igfa1-data-0.2.2/bonds.json
+++ b/src/assets/LCPs/igfa1-data-0.2.2/bonds.json
@@ -1,0 +1,193 @@
+[
+    {
+        "id": "igf-bond-influencer",
+        "name": "The Influencer",
+        "major_ideals": [
+            "I addressed challenges with charisma, personal magnetism or my connections.",
+            "I expressed my heritage, background or beliefs through my actions.",
+            "I struggled with issues from my burdens or background."
+        ],
+        "minor_ideals": [
+            "I made the whole thing about me.",
+            "I made a ridiculous boast and lived up to it.",
+            "I put a lot of new eyes on an important subject.",
+            "Someone else had the answer, and I knew how to get it from them."
+        ],
+        "questions": [
+            {
+                "question": "What gives you your powers?",
+                "options": [
+                    "An inimitable personal brand, cultivated over the year." ,
+                    "Daddy’s credit line.",
+                    "An unusually good sponsorship deal.",
+                    "The sale of your soul, figuratively or literally."
+                ]
+            },
+            {
+                "question": "What is most likely to harm your image?",
+                "options": [
+                    "Your controversial sociopolitical takes." ,
+                    "Your checkered family history.",
+                    "Your ill-conceived tattoo.",
+                    "Your past allegiances.",
+                    "Your rampant plagiarism.",
+                    "Your refusal to properly credit artists."
+                ]
+            }
+        ],
+        "powers": [
+            {
+                "name": "All Eyes on Me",
+                "description": "You can take 2 STRESS to immediately make yourself the center of attention. For a moment, everyone and everything looks at you and only you. People fail to register the presence of other people or things, and even security footage zooms in on you too tightly to keep track of anything else. After this moment ends, you’ll have to work if you want to hold their attention, and you can't use this power twice in the same scene."
+            },
+            {
+                "name": "Always an Audience",
+                "frequency": "1/session",
+                "description": "When you’re threatened by people who think they can do what they want because they outnumber you, or because nobody’s watching, you can reveal how you’re not as alone as they think. Either they back off <i>now</i>, or they choose two:<ul><li>You have some backup after all.</li><li>Everyone will know who they are and what they did.</li><li>That's not the only mistake they made.</li></ul>"
+            },
+            {
+                "name": "Carpe Diem // Carpe Noctem",
+                "frequency": "2/session",
+                "description": "<b>Carpe Diem</b>: When you do something totally reckless, ill-advised and dangerous just to look cool or impress people, you take 2 STRESS and get increased effect. This power then becomes <b>Carpe Noctem</b>.<br><b>Carpe Noctem</b>: When you show sudden wisdom, restraint or foresight that nobody expected from you, you take 2 STRESS and get +2 ACCURACY. This power then becomes <b>Carpe Diem</b>."
+            },
+            {
+                "name": "Everyone's a Fan",
+                "frequency": "2/session",
+                "description": "Upon first meeting a new person, if it seems plausible, you may declare that they’re a fan of yours. Roll a <b>d20</b>.<ul><li>On a <b>20</b>, oh my god, it’s really you! They’ll do almost anything for you, within reason.</li><li>On a <b>10-19</b>, they’re a fan, and they’re delighted to meet you. They’ll help you if it won’t cause trouble.</li><li>On a <b>2-9</b>, who?</li><li>On a <b>1</b>, oh, they’ve heard of you alright, and they fucking <i>loathe</i> you.</li></ul>"
+            },
+            {
+                "name": "Incomprehensible Memetic Subculture",
+                "description": "You can couch your spoken or written words in layers of reference and irony so obscure that, in practical terms, they are encrypted. Only the people for whom your message is intended can understand it; others perceive nonsense. This doesn’t automatically count as lying. It’s usually obvious that you’re doing this, but that doesn’t make deciphering it any easier."
+            },
+            {
+                "name": "On The List",
+                "description": "You can get into almost any meeting, private function or exclusive social gathering, simply through your own reputation or by namedropping a relevant person. This only gets you through the door; you will have to do the work of convincing those inside you belong there. For 2 STRESS, you can bring up to four other people along."
+            },
+            {
+                "name": "Oversharing",
+                "description": "You may clear 2 additional STRESS during downtime, but if you do, everyone knows exactly what you’ve been doing lately. What’s “opsec?”"
+            },
+            {
+                "name": "Plugged In",
+                "description": "If you don’t know it yourself, you know where to look for it or who to ask. As long as you have access to a major information network – the omninet, the Muse, a planet’s local internet – if you roll a 9< or lower on any check to research or find information, you may treat the result as a 10 instead. Accessing confidential, restricted or deeply obscure information this way is RISKY – you might still get it, but there’ll be consequences."
+            },
+            {
+                "name": "Reality Consensus",
+                "description": "You can manipulate the memory of crowds. In any gathering of more than six individuals, people tend to remember events occurring the way you recount them, so long as it doesn’t clash with obvious physical evidence. Gain +1 ACCURACY and increased effect on rolls where this is relevant."
+            },
+            {
+                "name": "Vindictive",
+                "frequency": "1/session",
+                "description": "When you Heal Burdens, you gain +1 ACCURACY on the check if you’re taking action to harm or inconvenience those you consider responsible for your suffering."
+            },
+            {
+                "name": "Boon of Exposure",
+                "prerequisite": "If you have two or more powers from this bond, you can choose a power from any other bond instead of one from this bond when you would gain a power. You can do this twice. If you have at least one veteran power, gain the Boon of Exposure.",
+                "description": "At the end of each session, if you think you did something really cool, name a person who’ll look better just for standing next to you. They get 1 XP.",
+                "veteran": true
+            },
+            {
+                "name": "Cancellation",
+                "prerequisite": "You may only gain this power If you’ve taken four powers from this bond, including the Veteran Power.",
+                "frequency": "1/session",
+                "description": "Choose an enemy. Accuse them of something truly awful. The searing gaze of public opinion falls upon them; they will be judged and found sorely wanting. For at least a scene, <i>nobody</i> will help them, and <i>everyone</i> will hate them. After that, if what you said is provably true, the stigma remains. If it’s likely but unproven, the stench of it taints them for a while afterward. If it’s clearly false, you’re next, <i>liar</i>.",
+                "master": true
+            }
+        ]
+    },
+    {
+        "id": "igf-bond-technician",
+        "name": "The Technician",
+        "major_ideals": [
+            "I addressed challenges with ingenuity, intuition or technical skill.",
+            "I expressed my heritage, background or beliefs through my actions.",
+            "I struggled with issues from my burdens or background."
+        ],
+        "minor_ideals": [
+            "I learnt a new and useful trick.",
+            "I made a skeptic appreciate my profession.",
+            "I trusted a gut feeling about what was wrong.",
+            "I kept things running smoothly, and nobody noticed."
+        ],
+        "questions": [
+            {
+                "question": "What gives you your powers?",
+                "options": [
+                    "A childhood spent crawling through vents and plugging air leaks." ,
+                    "The strict tutelage of a veteran in your field.",
+                    "A whole lot of trial and error.",
+                    "That strange, other voice that the comp/cons sometimes speak with."
+                ]
+            },
+            {
+                "question": "What was the thing you couldn’t fix?",
+                "options": [
+                    "Your family." ,
+                    "Your home.",
+                    "Your world.",
+                    "Your ship.",
+                    "Yourself."
+                ]
+            }
+        ],
+        "powers": [
+            {
+                "name": "Custom Tools",
+                "description": "Choose a specific field of work – for example, HVAC repair, reactor maintenance, contract negotiation, etc. Over the course of your career, you’ve assembled a personal toolbox, whether literal or metaphorical. Whenever you’re working in that field and you have access to your toolbox, you gain increased effect."
+            },
+            {
+                "name": "Fehlersinn",
+                "description": "You can look at something that’s broken and get a gut feeling of what went wrong. This doesn’t <i>necessarily</i> give you any information on how to fix it, but it might. You must be able to see and reach out to touch what’s broken, although the “seeing” and “reaching out” can be metaphorical."
+            },
+            {
+                "name": "Gordian Knot",
+                "frequency": "1/session",
+                "description": "When you or an ally you can see or hear fails a skill check, you may describe how you quickly improvise a simple, low-tech solution to the problem. The check succeeds instead, but you take 2 STRESS and choose one of the following:<ul><li>Your solution broke something else.</li><li>Your solution used up an important resource (time, supplies, scrap metal, patience, etc.)</li><li>Your solution attracted the wrong kind of attention.</li></ul>"
+            },
+            {
+                "name": "Improvised Equipment",
+                "description": "You’ve gotten used to working with whatever you have, no matter how insufficient and piecemeal it may be. You may choose to negate any amount of DIFFICULTY on a roll that comes from not having the proper tools, but whether or not your roll succeeds, choose one:<ul><li>The exact same problem is going to come back soon, and this time it’ll be worse.</li><li>Something personally important to you or someone else is broken, used up or gone.</li><li>You had to take real harm to make this work – physical, emotional, or psychological.</li></ul>"
+            },
+            {
+                "name": "Job Satisfaction",
+                "description": "When you mend something, anything – when you really, properly, truly fix it – you clear 1 STRESS."
+            },
+            {
+                "name": "Juice It",
+                "frequency": "1/session",
+                "description": "You know how to make something – almost always a piece of technology – operate significantly above its recommended output. For the rest of the scene, whatever you modify this way gives increased effect to any rolls that use it. At the end of the scene, it immediately and catastrophically breaks."
+            },
+            {
+                "name": "Percussive Maintenance",
+                "frequency": "2/session",
+                "description": "When you whack something inanimate to just make the godforsaken piece of shit <i>work</i>, choose one: it doesn’t help at all, but you clear 1 STRESS, or you take 2 STRESS and it awkwardly sputters back to life."
+            },
+            {
+                "name": "Proper Procedure",
+                "description": "Once you’ve done something a few times, you can do it by rote. If you’d roll a skill check for doing the exact same thing you’ve done several times before, you can choose to forgo the roll and treat the result as a 10-19. You can’t modify this result with ACCURACY or increased effect. If a task isn’t identical, just very similar, you still need to roll, but gain +1 ACCURACY."
+            },
+            {
+                "name": "Solidarity",
+                "description": "When you stand shoulder-to-shoulder with a crowd of people (at least ten) against a mutual threat, you gain +1 ACCURACY to all rolls and you ignore the first point of STRESS that you would receive in a scene. If it’s more than twenty, ignore the first two points of STRESS instead."
+            },
+            {
+                "name": "The Tower",
+                "frequency": "1/session",
+                "description": "A life of learning to fix things has also taught you how to take them apart. If you have comprehensive information about something – a machine, a system, an organization – you know exactly what will do the most damage to it, right now. Until the end of the scene, you gain increased effect on all efforts to put this knowledge into action."
+            },
+            {
+                "name": "Boon of the Wrench",
+                "prerequisite": "If you have two or more powers from this bond, you can choose a power from any other bond instead of one from this bond when you would gain a power. You can do this twice. If you have at least one veteran power, gain the Boon of the Wrench.",
+                "description": "At the end of each session, if you think a complicated problem was fixed, describe how the pieces came together. Give someone you think was instrumental in the solution 1 XP.",
+                "veteran": true
+            },
+            {
+                "name": "Vox Ad Machina",
+                "prerequisite": "You may only gain this power If you’ve taken four powers from this bond, including the Veteran Power.",
+                "frequency": "1/session",
+                "description": "Touch a non-sentient machine and tell it exactly what you want. If there’s even the slightest chance it could do what you ask, it does so, at precisely the moment you need it to. Then the GM chooses one of the following:<ul><li>The machine will never work again, ever.</li><li>The machine exacts a heavy price in return.</li><li>The machine is no longer non-sentient.</li></ul>",
+                "master": true
+            }
+        ]
+    }
+]

--- a/src/assets/LCPs/igfa1-data-0.2.2/index.js
+++ b/src/assets/LCPs/igfa1-data-0.2.2/index.js
@@ -1,0 +1,25 @@
+"use strict";
+// In Golden Flame Act 1 — Powered By LANCER campaign supplement.
+// Authors: Vex, Psicrystal, and Cruye. Item prefix: igfa1.
+//
+// Source LCP also ships npc_classes, npc_features, and backgrounds
+// JSON files that this site doesn't currently render — they are
+// intentionally omitted here so the bundle only carries data we
+// actually look up. Drop additional imports below when / if NPC or
+// background UI is added later.
+
+import b from "./bonds.json";
+import g from "./pilot_gear.json";
+import sk from "./skills.json";
+import s from "./systems.json";
+import w from "./weapons.json";
+
+const data = {
+	bonds: b,
+	pilot_gear: g,
+	skills: sk,
+	systems: s,
+	weapons: w,
+};
+
+export default data;

--- a/src/assets/LCPs/igfa1-data-0.2.2/pilot_gear.json
+++ b/src/assets/LCPs/igfa1-data-0.2.2/pilot_gear.json
@@ -1,0 +1,71 @@
+[
+  {
+    "id": "igfa1_pg_ahab_grapple",
+    "name": "IPS-N “Ahab” Grapple/Tether Line",
+    "type": "Gear",
+    "description": "“You ever get the feeling nobody at IPS-N spends any time thinking about the names they give to things? Like, either I don’t read, so I don’t get the reference, or I do and I realize they named a survival tool after a dude who’s famous exclusively for getting dragged to his death tied to a whale.”",
+    "actions": [{
+      "name": "Use Grapple",
+      "activation": "Quick",
+      "detail": "Expend a charge to shoot a hook at a character, object or free space up to Range 5 away from you. You are attached to the hook by a tether, and cannot move or be moved further than five spaces away, unless you teleport, in which case the tether snaps. If the hook moves more than five spaces away, you are dragged along with it. As a quick action, you can reel yourself in, flying to the hook or as close to it as possible. This movement ignores engagement and doesn’t provoke reactions. You can detach from the tether as a full action. You can also retrieve a hook and tether that you are adjacent to as a full action, restoring a charge.",
+      "pilot": true
+    }],
+    "tags": [{
+      "id": "tg_limited",
+      "val": 3
+    }]
+  },
+  {
+    "id": "igfa1_pg_scramble_grenade",
+    "name": "Scramble Grenade",
+    "type": "Gear",
+    "description": "This is a modified short-range distress beacon meant to help search-and-rescue teams locate astronauts who’ve been thrown into space. Some asshole discovered that if you jam a bunch of escape characters into the broadcast signal and overvolt the transmitter, you can make unshielded electronics shit themselves. It fries itself after a few seconds, a fate many wrenchies have wished upon its inventor. Expend a charge for the following effect:<ul><li><b>Scramble Grenade</b> (Grenade, Range 5, Blast 1): Affected characters without the Biological tag must succeed on a Systems save against 10 + your Grit or become Jammed until the end of their next turn.</li></ul>",
+    "actions": [{
+      "name": "Use Scramble Grenade",
+      "activation": "Quick",
+      "range": [{
+          "type": "Range",
+          "val": 5
+        },
+        {
+          "type": "Blast",
+          "val": 1
+        }
+      ],
+      "detail": "Throw a grenade within Range 5. Affected characters without the Biological tag must succeed on a Systems save against 10 + your Grit or become Jammed until the end of their next turn.",
+      "pilot": true
+    }],
+    "tags": [{
+        "id": "tg_limited",
+        "val": 1
+      },
+      {
+        "id": "tg_grenade"
+      }
+    ]
+  },
+  {
+    "id": "igfa1_pg_portable_power_supply",
+    "name": "Portable Power Supply",
+    "type": "Gear",
+    "description": "Slightly larger than a briefcase, this device contains a fuel cell capable of generating enough electricity to run a family house for several days, or a moderate number of personal appliances indefinitely. On Hell’s Gate, wrenchies often carry one of these to provide power to computers or machinery in areas of the station that have been cut off from the main grid.<pg>It can’t generate enough power to run a mech’s weapons or motive systems, but it can keep the main computer, comms and life support running."
+  },
+  {
+    "id": "igfa1_pg_sylphlex",
+    "name": "Sylphlex",
+    "type": "Gear",
+    "description": "An example of outlander ingenuity, the Sylphlex was a successful attempt to merge the features of an SSC Sylph Undersuit and a flexsuit into a single unit. This provides a base-layer suit that recycles air and water, deals with waste products, cleans the user, maintains a supply of nutritional paste and seals against external atmosphere, allowing a user to wear a hardsuit comfortably for days or weeks without having to remove it; essential for long journeys.<br>Given that the Sylphlex suit is an unauthorized modification of its proprietary technology, SSC briefly considered legal action, but their local office convinced them that suing a group of impoverished Long Rim residents would be a PR disaster. Instead, they granted outlanders the exclusive right to manufacture Sylphlex suits in Calliope, while SSC retains rights to the product elsewhere in the galaxy."
+  },
+  {
+    "id": "igfa1_pg_headache",
+    "name": "Headache",
+    "type": "Gear",
+    "description": "Headache is a lesson in how outlanders describe things: bluntly. It’s a volatile liquid that’s usually a clear golden-brown color. Few know what it’s made from and the rest know better than to ask. It’s 100 proof at the very least, so it can disinfect wounds, degrease the moving parts of your mech, act as an accelerant and if you’re very, very brave you can even try drinking it – but take note of the name."
+  },
+  {
+    "id": "igfa1_pg_the_soup",
+    "name": "The Soup",
+    "type": "Gear",
+    "description": "Outlanders, particularly nomads, often have to keep their hardsuits on for days or weeks. A Sylphlex provides an edible paste that contains the essentials, but it’s like eating packing foam. To address this problem, outlanders created “the Soup” – a nutrient-rich liquid that comes in a variety of flavors and can be drank via a standard hardsuit port. The flavors are named only as colors; cinnabar, ochre and saffron are favorites, while fern is an acquired taste. Stay away from ultramarine."
+  }
+]

--- a/src/assets/LCPs/igfa1-data-0.2.2/skills.json
+++ b/src/assets/LCPs/igfa1-data-0.2.2/skills.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "igfa1_sk_jury_rig",
+    "name": "JURY RIG",
+    "description": "Make something broken work a little while longer.",
+    "detail": "Make something broken work a little while longer; improvise a quick solution with limited materials; use ingenuity to avert disaster. This skill implies that you don’t have the necessary expertise, tools or materials to do the job properly and to code. Whatever fix you apply won’t last long, but it’ll be better than nothing.",
+    "family": "dex"
+  },
+  {
+    "id": "igfa1_sk_hack_or_finesse",
+    "name": "HACK OR FINESSE",
+    "description": "Make technology do something it’s not supposed to.",
+    "detail": "Make technology do something it’s not supposed to; exploit weaknesses in design or implementation; break into secure systems; see things you shouldn’t; override safety features or failsafes; modify or sabotage in ways that are hard to detect.",
+    "family": "int"
+  },
+  {
+    "id": "igfa1_sk_repair_and_maintain",
+    "name": "REPAIR AND MAINTAIN",
+    "description": "Keep something working, or restore proper functionality to something that’s not.",
+    "detail": "Keep something working, or restore proper functionality to something that’s not; ensure a piece of equipment is clean, reliable and safe to use; fix something the correct way. This skill implies you have the expertise, tools and materials to do a job the way it’s meant to be done.",
+    "family": "int"
+  },
+  {
+    "id": "igfa1_sk_attune_to_the_world",
+    "name": "ATTUNE TO THE WORLD",
+    "description": "Let your surroundings speak to you.",
+    "detail": "Let your surroundings speak to you; see the method in the madness; perceive hidden patterns; work out what doesn’t fit; know things you can’t quite explain; sneak a glimpse of the bigger picture.",
+    "family": "dex"
+  },
+  {
+    "id": "igfa1_sk_conceptualize",
+    "name": "CONCEPTUALIZE",
+    "description": "Exercise imagination and derive meaning.",
+    "detail": "Exercise imagination; derive meaning; comprehend forms; see something from a different perspective; draw connections; think outside the box; create and communicate ideas; recognize artistic intent and purpose. Useful in any job, vital for artists.",
+    "family": "dex"
+  },
+  {
+    "id": "igfa1_sk_deceive",
+    "name": "DECEIVE",
+    "description": "Say things contrary to established fact.",
+    "detail": "Say things contrary to established fact; commit false report; speak untruths; verify unjust things; converse in bad faith; dissemble; mislead; conceal your intentions; equivocate; prevaricate; spin yarns; in short, lie.",
+    "family": "dex"
+  },
+  {
+    "id": "sk_push_boundaries",
+    "name": "PUSH BOUNDARIES",
+    "description": "Get what you want by being a dick about it.",
+    "detail": "Get what you want by being a dick about it; break the rules; skirt regulations; disregard procedure; ignore the chain of command; exploit loopholes; obey the letter of the law while mocking its spirit; comply in a malicious manner; take advantage.",
+    "family": "cha"
+  }
+]

--- a/src/assets/LCPs/igfa1-data-0.2.2/systems.json
+++ b/src/assets/LCPs/igfa1-data-0.2.2/systems.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "ms_exo_bronco_hook",
+    "name": "BRONCO HOOK",
+    "sp": 2,
+    "tags": [{
+      "id": "tg_unique"
+    }, {
+      "id": "tg_exotic"
+    }],
+    "source": "EXOTIC",
+    "actions": [{
+        "activation": "Quick",
+        "detail": "Choose a character within Range 5 and line of sight. They make an AGILITY save. If they fail, you embed a hooked cable in the target. You and the target may not move more than 5 spaces away from each other. Either character can tow the other, obeying the normal rules for lifting and dragging, and becoming SLOWED while doing so.<br>Any character can remove the cables on a hit with a melee attack or IMPROVISED ATTACK against EVASION 15. The hooked character can also rip the hook out with a quick action, but they take 3 AP kinetic damage and become SHREDDED until the end of their next turn if they do so."
+      }],
+    "description": "An old favorite of both pirates and the people who fight them, this is a wrist-mounted magnetic accelerator, originally designed to make tether points on asteroids by driving mech-scale pitons into them. Rule of thumb is if it punches through a meter of asteroid rock, it punches through ten centimeters of mech."
+  },
+  {
+    "id": "ms_exo_rebound_pulse_mineral_scanner",
+    "name": "REBOUND PULSE MINERAL SCANNER",
+    "type": "Tech",
+    "sp": 1,
+    "tags": [{
+      "id": "tg_unique"
+    }, {
+      "id": "tg_exotic"
+    }],
+    "source": "EXOTIC",
+    "actions": [{
+        "name": "Rebound Pulse",
+        "activation": "Quick Tech",
+        "detail": "1/mission, you may activate this system to Scan every character in a Cone 7 area, then apply Lock On to the character with the most current HP. All hostile characters in the area also lose Hidden."
+      }],
+    "description": "A simple piece of tech found on almost every mining ship, modified to provide an effective battlefield reconnaissance tool. Its minimum safe stand-off distance is several hundred kilometers; anything less, and the ping-back is loud enough to blow out the antenna."
+  },
+  {
+    "id": "ms_exo_cardcounter",
+    "name": "CARDCOUNT_V7.7.7_FINAL.OMEX",
+    "sp": 2,
+    "tags": [{
+      "id": "tg_unique"
+    },
+    {
+      "id": "tg_heat_self",
+      "val": 2
+    }, 
+    {
+      "id": "tg_exotic"
+    }],
+    "source": "EXOTIC",
+    "actions": [{
+        "name": "Count Cards",
+        "activation": "Protocol",
+        "detail": "For the rest of the turn, this system becomes charged and you can’t take full actions until the start of your next turn.<br>If, during a quick action, you make an attack roll that misses or force a save that an enemy passes, expend the system’s charge. That quick action didn’t really happen; your probability calculation returned an unfavorable result. Limited charges aren’t expended, loading weapons aren’t unloaded, reactions aren’t triggered, and so on. You must then choose a different quick action, and perform it instead.<br>If you don’t use it, this system loses its charge at the end of your turn, as the calculation’s initial conditions no longer reflect reality."
+      }],
+    "description": "Card-counting devices and programs are banned everywhere on the Icebreaker; it’s one of the few things the Board can agree on. What makes this specific distro special (and even more illegal) is that, somehow, it can also predict slot machines, roulette wheels and mech fights. Programmers hired to examine it reported a tangle of neural-network-written paracode that seems to call variables antichronally."
+  }
+]

--- a/src/assets/LCPs/igfa1-data-0.2.2/weapons.json
+++ b/src/assets/LCPs/igfa1-data-0.2.2/weapons.json
@@ -1,0 +1,439 @@
+[
+  {
+    "id": "igfa1_mw_exo_the_grabber",
+    "name": "The Grabber",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Heavy",
+    "type": "Melee",
+    "range": [{
+      "type": "Threat",
+      "val": 2
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "2d6"
+    }],
+    "effect": "",
+    "on_hit": "you and your target each roll a contested Hull check. If you win the contested roll, your target is knocked Prone.",
+    "description": "A standard piece of equipment found on mining and salvage rigs throughout the system; its official product name is the IPS-N Mechanized Chassis Remote Handling Tool, but that’s boring as hell, so most folks call it “the Grabber.” Little work is needed to make it grab mechs as effectively as space debris, although such modification does void the warranty.",
+    "tags": [{
+      "id": "tg_exotic"
+    }]
+  },
+  {
+    "id": "igfa1_mw_exo_hyperkinetic_gauntlet",
+    "name": "Hyperkinetic Gauntlet",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Main",
+    "type": "Melee",
+    "effect":"This weapon can be used while unloaded, using a different profile.",
+    "profiles": [
+      {
+        "name": "Loaded",
+        "damage": [
+          {
+            "type": "Explosive",
+            "val": "1d6+4"
+          }
+        ],
+        "range": [
+          {
+            "type": "Threat",
+            "val": 1
+          }
+        ],
+        "tags": [
+          {
+            "id": "tg_loading"
+          },
+          {
+            "id": "tg_knockback",
+            "val": 1
+          }
+        ]
+      },
+      {
+        "name": "Unloaded",
+        "damage": [
+          {
+            "type": "Kinetic",
+            "val": "1d3+1"
+          }
+        ],
+        "range": [
+          {
+            "type": "Threat",
+            "val": 1
+          }
+        ],
+        "on_crit": "If this weapon is unloaded, reload it."
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_exotic"
+      }
+    ],
+    "description": "Inspired by the legend of Xiong Xiaoli, Hell’s Gate militia pilot Iska “Limbo” Volkov cobbled together a miniaturized approximation of the DD-288. While it didn’t quite live up to the mythic “Horse-Killing Palm,” it also places much less stress on a mech’s structure and doesn’t require reactor modifications.<br>Iska went on to achieve the highest confirmed kill count of any pilot in the Gate’s militia, but eventually retired to help her wife coach the station’s gravball team, stating that mech combat had grown “too peaceful” for her."
+  },
+  {
+    "id": "igfa1_mw_exo_leech_hunter_blade",
+    "name": "Leech Hunter's Blade",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Main",
+    "type": "Melee",
+    "on_crit": "If this weapon is not revved up, it becomes revved up before damage is rolled.",
+    "profiles": [
+      {
+        "name": "Unrevved",
+        "damage": [
+          {
+            "type": "Kinetic",
+            "val": "1d6+1"
+          }
+        ],
+        "range": [
+          {
+            "type": "Threat",
+            "val": 1
+          }
+        ],
+        "on_crit": "If this weapon is not revved up, it becomes revved up before damage is rolled.",
+        "effect": "You can rev up this weapon as a quick action.",
+        "actions": [
+          {
+            "name": "Rev Up!",
+            "activation": "Quick",
+            "detail": "Rev up the Leech Hunter's Blade, Slowing your mech and allowing use of its \"Revved Up!!!\" profile."
+          }
+        ],
+        "tags": [
+          {
+            "id": "tg_accurate"
+          }
+        ]
+      },
+      {
+        "name": "Revved Up!!!",
+        "damage": [
+          {
+            "type": "Burn",
+            "val": "1d3+4"
+          }
+        ],
+        "range": [
+          {
+            "type": "Threat",
+            "val": 1
+          }
+        ],
+        "actions": [
+          {
+            "name": "Rev Down...",
+            "activation": "Protocol",
+            "detail": "Rev down the Leech Hunter's Blade, ending the Slowed condition and allowing the Assault Cannon to be used with its \"Unrevved\" profile."
+          }
+        ],
+        "tags": [
+          {
+            "id": "tg_overkill"
+          },
+          {
+            "id": "tg_heat_self",
+            "val": 2
+          }
+        ]
+      }
+    ],
+    "tags": [
+      {
+        "id": "tg_unique"
+      },
+      {
+        "id": "tg_exotic"
+      }
+    ],
+    "description": "Sarissa \"Nova Cat\" Kairos developed this weapon more than eighty years ago during her one-woman campaign of vengeance against the Sun Drinkers pirate clan. A rotary rock-cutting saw modified to tolerate vented coldcore plasma, all it takes is the flick of a switch to turn this blade into a screaming, white-hot abomination that slices through armor like butter.<br>Stories differ as to what happened to Nova Cat and her original blade, but she left the schematics to her niece, who went on to produce several hundred copies and become one of the founding members of the Board of Icebreaker."
+  },
+  {
+    "id": "igfa1_mw_exo_golden_hand",
+    "name": "The Golden Hand",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Auxiliary",
+    "type": "CQB",
+    "range": [
+      {
+        "type": "Range",
+        "val": 5
+      },
+      {
+        "type": "Threat",
+        "val": 3
+      }
+    ],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "1d6"
+    }],
+    "on_crit": "After this attack, reload every weapon in this mount.",
+    "effect": "If you install the Golden Hand in the same mount as the Crimson Hand, they count as only one piece of Exotic Gear for installation limits.",
+    "description": "Marika was fast as lightning, and she had to be: she couldn’t aim worth a damn. Zhihao was quick to mock her wide shots, and it made her blush.<br>When your mech levels it, you smell whiskey, cigar smoke and rose perfume, hear the sound of dancing, and you want to laugh like the devil.",
+    "tags": [
+      {
+        "id": "tg_loading"
+      },
+      {
+        "id": "tg_reliable",
+        "val": 1
+      },
+      {
+        "id": "tg_unique"
+      },
+      {
+      "id": "tg_exotic"
+    }]
+  },
+  {
+    "id": "igfa1_mw_exo_catastrophe_beam",
+    "name": "Catastrophe Beam",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Superheavy",
+    "type": "Cannon",
+    "range": [
+      {
+        "type": "Line",
+        "val": 20
+      }
+    ],
+    "damage": [
+      {
+        "type": "Energy",
+        "val": "3d6"
+      },
+      {
+        "type": "Burn",
+        "val": 8
+      }
+    ],
+    "effect": "You must charge the Catastrophe Beam as a quick action before it can be fired. While the weapon is charged, you are Immobilized and cannot lose Heat by any means except overheating, but you benefit from soft cover. This weapon loses its charge when you fire it.",
+    "actions": [
+      {
+        "name": "Charge Catastrophe Beam",
+        "activation": "Quick",
+        "detail": "The Catastrophe Beam becomes charged, and can be fired. While the Catastrophe Beam is charged, you are Immobilized and cannot lose Heat by any means except overheating, but you benefit from soft cover."
+      }
+    ],
+    "on_attack": "This weapon automatically deals 30 AP Energy damage to all cover, terrain, and objects in its area. All characters within Burst 2 of you must make a Hull save or be pushed outside the area and knocked Prone.",
+    "description": "“I’m not going to bother writing any safety protocols in the documentation for this weapon. It’s not safe to fire under any circumstances, but I doubt that will stop you.”<br>- Dr. Genevieve Nyambose",
+    "tags": [
+      {
+      "id": "tg_heat_self",
+      "val": 8
+      },
+      {
+      "id": "tg_ordnance"
+      },
+      {
+      "id": "tg_exotic"
+    }]
+  },
+  {
+    "id": "igfa1_mw_exo_id_balistaria",
+    "name": "ID-390 “Balistaria” Marksman Rifle",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Heavy",
+    "type": "Rifle",
+    "range": [{
+      "type": "Range",
+      "val": 12
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "1d6+2"
+    }],
+    "effect": "Attacks with this weapon gain +1 Accuracy if you haven't moved since the end of your last turn.",
+    "description": "Impact Dynamics, noting the shortcomings of GMS anti-materiel rifles, produced a more compact, portable designated marksman weapon. While it couldn’t beat GMS’ offerings on raw stopping power or range, it matched them almost shot-for-shot on accuracy while allowing a level of battlefield maneuverability that simply wasn’t possible for larger, heavier weapons.<br>Unfortunately, before the weapon could enter full production, the company pivoted to agriculture and most of its ballistics projects were shuttered. The ID-390 remains popular among professional mercenaries, however, with some outfits travelling all the way to Calliope just to acquire a licensed printcode. ",
+    "tags": [
+    {
+      "id": "tg_ap"
+    },
+    {
+      "id": "tg_exotic"
+    }]
+  },
+  {
+    "id": "igfa1_mw_exo_id_obelisk",
+    "name": "ID-440 “Obelisk” Kinetic Repeater",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Heavy",
+    "type": "Cannon",
+    "range": [{
+      "type": "Range",
+      "val": 5
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "2d6"
+    }],
+    "effect": "",
+    "on_hit": "Make a secondary attack against all characters in a Cone 3 area directly behind the target. These attacks lose AP, can’t deal bonus damage and don’t trigger further secondary attacks. This effect triggers automatically if the attack is made against a piece of hard cover.",
+    "description": "Intended as an answer to the GMS heavy machine gun, the Obelisk failed to wow the market. Its proprietary Overpenetrator rounds are failure-prone and incompatible with other firearms, its recoil is considered unmanageable even by the standards of its weight class, and its range leaves much to be desired. Nevertheless, Impact Dynamics made thousands of them for a contact that never got fulfilled.",
+    "tags": [
+    {
+      "id": "tg_ap"
+    },
+    {
+      "id": "tg_inaccurate"
+    },
+    {
+      "id": "tg_exotic"
+    }
+   ]
+  },
+  {
+    "id": "igfa1_mw_exo_id_hardcastle",
+    "name": "ID-730 “Hardcastle” Automatic Shotgun",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Main",
+    "type": "CQB",
+    "range": [{
+      "type": "Range",
+      "val": 3
+    },
+    {
+      "type": "Threat",
+      "val": 3
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "2d6"
+    }],
+    "effect": "If Overkill triggers, this weapon doesn’t need to be reloaded.",
+    "description": "The ID-730 was undergoing its first design revision when Impact Dynamics abandoned weapons development. Results from the initial release were promising, but its trigger had an unfortunate tendency to “run away,” emptying entire magazines or melting the barrel.",
+    "tags": [
+    {
+      "id": "tg_loading"
+    },
+    {
+      "id": "tg_overkill"
+    },
+    {
+      "id": "tg_unique"
+    },
+    {
+      "id": "tg_exotic"
+    }
+   ]
+  },
+  {
+    "id": "igfa1_mw_exo_id_sermon",
+    "name": "ID-820 “Sermon” Compact SMG",
+    "source":"EXOTIC",
+    "license":"",
+    "license_level":0,
+    "mount": "Auxiliary",
+    "type": "CQB",
+    "range": [{
+      "type": "Range",
+      "val": 5
+    },
+    {
+      "type": "Threat",
+      "val": 3
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "1d3+1"
+    }],
+    "effect": "Any number of ID-820 “Sermon” Compact SMGs installed on the same mech count as only one piece of Exotic Gear for installation limits.",
+    "description": "Impact Dynamics designed he ID-820 with one goal: put as much lead downrange, in as little time, with as little recoil, in as tight a frame as possible. It hit all of these targets, and was one of the company’s flagship products before it switched to agriculture. It’s proven so popular that Impact Dynamics still revises and updates it on occasion.",
+    "tags": [
+    {
+      "id": "tg_reliable",
+      "val": 1
+    },
+    {
+      "id": "tg_exotic"
+    }
+   ]
+  },
+  {
+    "id": "igfa1_mw_exo_starquake",
+    "name": "“Starquake” Quad-Barrel Shotgun",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Heavy",
+    "type": "CQB",
+    "range": [{
+      "type": "Range",
+      "val": 3
+    },
+    {
+      "type": "Threat",
+      "val": 3
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "2d6+3"
+    }],
+    "on_attack": "If your mech is Size 1 or smaller, you are knocked 1 space back from your target.",
+    "effect": "",
+    "description": "This appears to be a Conical Kinetic Projector from a subline starship, clumsily patched into the firing mechanism of a mech-scale shotgun. Little thought seems to have been given to how it would handle, meaning that low-tonnage mechs can actually be lifted slightly off the ground by the sheer force of its recoil.",
+    "tags": [
+    {
+      "id": "tg_reliable",
+      "val": 3
+    },
+    {
+      "id": "tg_inaccurate"
+    },
+    {
+      "id": "tg_exotic"
+    }
+   ]
+  },
+  {
+    "id": "igfa1_mw_tripled_point",
+    "name": "Tripled Point",
+    "source":"EXOTIC",
+    "license_id": "",
+    "license_level":0,
+    "mount": "Main",
+    "type": "Nexus",
+    "range": [{
+      "type": "Range",
+      "val": 10
+    }],
+    "damage": [{
+      "type": "Kinetic",
+      "val": "1d3+1"
+    }],
+    "effect": "This weapon makes three attacks at once, each of which must be against a different target. Attack and damage rolls are made normally, but only one of these attacks actually happens; you choose which.<br>The other two attacks don’t happen; damage isn’t dealt, Lock On isn’t consumed, effects are not triggered and the attack does not count as multi-target. Reactions to each attack must be declared before you decide which one is real, but only trigger if they apply to the real attack.<br>For the purposes of talents, systems and core bonuses that apply only once a round or activate on the first attack of a round, all three attacks qualify.",
+    "description": "Though the light inside has departed, it still whispers to you of all the things that could have been, and might yet be.",
+    "sp": 1,
+    "tags": [{
+      "id": "tg_smart"
+    }, {
+      "id": "tg_unique"
+    }, {
+      "id": "tg_exotic"
+    }]
+  }
+]

--- a/src/assets/LCPs/index.js
+++ b/src/assets/LCPs/index.js
@@ -8,6 +8,7 @@ import sotwData from "./sotw-data-1.0.2";
 import owsData from "./ows-data-1.0.0";
 import dustgraveData from "./dustgrave-data-1.4.0";
 import sirenData from "./siren-song-data";
+import igfa1Data from "./igfa1-data-0.2.2";
 
 // Order matters: lancer's canonical data first so its IDs win on any conflict.
 const sources = [
@@ -21,6 +22,7 @@ const sources = [
 	owsData,
 	dustgraveData,
 	sirenData,
+	igfa1Data,
 ];
 
 const collect = (key) =>


### PR DESCRIPTION
## Summary

New campaign supplement: **In Golden Flame Act 1** by Vex, Psicrystal, and Cruye (item prefix \`igfa1\`, manifest version 0.2.2). Imports its player-facing content into the central LCP registry so pilots / mechs that reference IGFA1 items resolve correctly.

## Files migrated

| File | Lines | Key |
|---|---:|---|
| \`bonds.json\` | 192 | \`bonds\` |
| \`pilot_gear.json\` | 70 | \`pilot_gear\` |
| \`skills.json\` | 50 | \`skills\` |
| \`systems.json\` | 57 | \`systems\` |
| \`weapons.json\` | 438 | \`weapons\` |

## Skipped on purpose

The source LCP also ships \`npc_classes.json\`, \`npc_features.json\`, and \`backgrounds.json\`. The site has no UI that reads any of those keys, so importing them would only inflate the bundle. They're easy to add later if NPC or background views ever ship — just drop the imports into \`src/assets/LCPs/igfa1-data-0.2.2/index.js\` and they flow through automatically.

## Touched files

- **src/assets/LCPs/igfa1-data-0.2.2/** (new folder) — five player JSONs + an \`index.js\` wrapper that mirrors the existing per-LCP shape (wallflower, osr, sotw, ows, dustgrave, siren-song).
- **src/assets/LCPs/index.js** — adds \`igfa1Data\` to the \`sources\` array. The new LCP slots in at the end so lancer's canonical data still wins on any ID conflict, per the existing ordering comment.

## Test plan

- [x] Build passes locally (\`npm run build\` — confirmed 4s on this branch)
- [x] Open a pilot whose loadout references an \`igfa1_*\` item (e.g. \`igfa1_mw_exo_the_grabber\` weapon, \`igfa1_pg_ahab_grapple\` gear) — chip resolves to the item name instead of \"ERR: DATA NOT FOUND\"
- [x] No regression for pilots that reference items from other LCPs (their lookups still hit the canonical lancer-data first)