### PR TITLE
Fix EVENT LOG header gap on mobile

### DIFF
--- a/src/assets/styles/_base.css
+++ b/src/assets/styles/_base.css
@@ -438,6 +438,15 @@ section.section-container#events-logs .rhombus-back {
 	left: -2em;
 }
 
+/* Fixed-height wrapper that clips the decorative rhombus-back tucked
+   behind the EVENT LOG header. Height matches the desktop section-header
+   (52px); the mobile breakpoint shrinks it to the mobile header height so
+   no background gap opens up between the bar and the content box. */
+.events-logs-header-wrap {
+	height: 52px;
+	overflow: hidden;
+}
+
 .event-list-container {
 	height: 666px;
 }

--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -688,6 +688,13 @@ body > canvas {
 		gap: 10px;
 	}
 
+	/* The EVENT LOG header lives inside a fixed-height wrapper. Match it to
+	   the shrunken mobile header (44px) so the red bar meets the content box
+	   instead of leaving a background gap below it. */
+	.events-logs-header-wrap {
+		height: 44px;
+	}
+
 	section .section-header h2 {
 		font-size: 20px;
 		white-space: nowrap;

--- a/src/views/EventsView.vue
+++ b/src/views/EventsView.vue
@@ -17,7 +17,7 @@
 			</div>
 		</section>
 		<section id="events-logs" :class="{ animate: animate }" class="section-container">
-			<div style="height: 52px; overflow: hidden">
+			<div class="events-logs-header-wrap">
 				<div class="section-header clipped-medium-backward-events-logs">
 					<i class="filter-icon" style="--icon-url: url('/icons/conversation.svg')"></i>
 					<h2>EVENT LOG</h2>


### PR DESCRIPTION
## Problema

Na versão mobile, o cabeçalho **EVENT LOG** (EventsView) mostrava uma leve separação — uma faixa do fundo da página aparecia entre a barra vermelha do título e a caixa de conteúdo branca, diferente da seção **BEATS**.

## Causa

O cabeçalho do EVENT LOG fica dentro de um wrapper com `height: 52px` fixo (definido inline), dimensionado para o `.section-header` do desktop. No breakpoint mobile (`max-width: 767px`) o `.section-header` encolhe para `44px`, mas o wrapper continuava com 52px — deixando ~8px de fundo visíveis abaixo da barra.

## Correção

- Substituí o `style="height: 52px"` inline por uma classe `.events-logs-header-wrap`.
- Defini a classe em `_base.css` (52px no desktop, comportamento idêntico ao anterior).
- No breakpoint `max-width: 767px` (`_responsive.css`), reduzi para `44px`, alinhando a barra à caixa de conteúdo.

Layout desktop inalterado. Build (`npm run build`) passa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
