### PR TITLE
docs: README aponta projeto original (Kuenaimaku/lancer-briefings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 **[Live Demo](https://lancer.kuenaimaku.com/)**
 
-Briefings de missão estilizados pro LANCER RPG: tela animada com tema Mirrorsmoke Mercenary Company, vistas de Status / Pilotos / Pelotões / Logs e PWA pra mostrar pros jogadores na mesa.
+Stylized mission briefings for the LANCER RPG: animated screen with a Mirrorsmoke Mercenary Company theme, Status / Pilots / Squads / Logs views, and PWA support for showing players at the table.
 
-## Sobre este projeto
+## About this project
 
-Este repositório foi originalmente um fork de [Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings) (o "Lancer Briefings" original do Kuenaimaku), mas evoluiu o bastante desde então (suite de testes, mobile drawer, squad roster, integração CompCon expandida, novos componentes) e por isso foi removido da rede de forks do GitHub.
+This repository started as a fork of [Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings) (the original "Lancer Briefings" by Kuenaimaku), but has diverged enough since then (test suite, mobile drawer, squad roster, expanded CompCon integration, new components) that it was detached from the GitHub fork network.
 
-**O design, a estrutura e o trabalho original são do Kuenaimaku** — esta versão é uma evolução de uso pessoal sobre a base dele. Se você quer a versão upstream com o escopo original, vá pra [Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings).
+**The original design, structure, and core work are by Kuenaimaku** — this is a personal evolution on top of that foundation. If you want the upstream version with the original scope, head to [Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings).
 
 ## Credits
 
-- **[Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings)** — projeto original sobre o qual este é baseado.
+- **[Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings)** — original project this one is based on.
 - Alkyama#2737 (discord) for the original [Figma Template](figma.com/community/file/983540597915480981) used as reference.
 - [VantaJS](https://www.vantajs.com/) for the slick 3d openGL backgrounds.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@
 
 **[Live Demo](https://lancer.kuenaimaku.com/)**
 
-Go over mission briefings within the LANCER Universe in style by showing your players a fully animated mission briefing screen, with a Mirrorsmoke Mercenary Company theme.
+Briefings de missão estilizados pro LANCER RPG: tela animada com tema Mirrorsmoke Mercenary Company, vistas de Status / Pilotos / Pelotões / Logs e PWA pra mostrar pros jogadores na mesa.
+
+## Sobre este projeto
+
+Este repositório foi originalmente um fork de [Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings) (o "Lancer Briefings" original do Kuenaimaku), mas evoluiu o bastante desde então (suite de testes, mobile drawer, squad roster, integração CompCon expandida, novos componentes) e por isso foi removido da rede de forks do GitHub.
+
+**O design, a estrutura e o trabalho original são do Kuenaimaku** — esta versão é uma evolução de uso pessoal sobre a base dele. Se você quer a versão upstream com o escopo original, vá pra [Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings).
 
 ## Credits
 
+- **[Kuenaimaku/lancer-briefings](https://github.com/Kuenaimaku/lancer-briefings)** — projeto original sobre o qual este é baseado.
 - Alkyama#2737 (discord) for the original [Figma Template](figma.com/community/file/983540597915480981) used as reference.
 - [VantaJS](https://www.vantajs.com/) for the slick 3d openGL backgrounds.
 


### PR DESCRIPTION
## Summary

O repositório foi removido da rede de forks do GitHub (já divergiu muito do upstream), mas o trabalho original do Kuenaimaku continua sendo a base. Atualiza o README pra:

- Adicionar seção **Sobre este projeto** explicando que era fork e por que não é mais.
- Linkar pro repo original em destaque tanto no contexto quanto nos credits.
- Atribuir explicitamente design + estrutura ao Kuenaimaku.
- Atualizar a descrição pra refletir o que o projeto faz hoje (vistas Status/Pilotos/Pelotões/Logs, PWA).