### PR TITLE
feat(boot-screen): per-faction boot terminal on first load

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,9 @@
 <template>
+	<BootScreen
+		v-if="showBootScreen"
+		:theme-key="themePrefs.theme"
+		@done="onBootDone"
+	/>
 	<div class="page-wrapper">
 		<Header :planet-path="planetPath" :class="{ animate: animate }" :header="header" />
 		<Sidebar :animate="animate" :class="{ animate: animate }" @open-settings="openSettings" />
@@ -24,6 +29,7 @@
 </template>
 
 <script>
+import BootScreen from "./components/BootScreen.vue";
 import Header from "./components/layout/Header.vue";
 import Sidebar from "./components/layout/Sidebar.vue";
 import SettingsModal from "./components/modals/SettingsModal.vue";
@@ -63,6 +69,7 @@ function buildVantaConfig({ theme, mode }) {
 
 export default {
 	components: {
+		BootScreen,
 		Header,
 		Sidebar,
 	},
@@ -75,6 +82,9 @@ export default {
 			header: Config.header,
 			pilotSpecialInfo: Config.pilotSpecialInfo,
 			themePrefs: this.loadThemePrefs(),
+			// Boot screen runs on first load. Set `bootScreen: false` in
+			// general-config.json to skip it.
+			showBootScreen: Config.bootScreen !== false,
 			vantaEffect: null,
 			clocks: [],
 			events: [],
@@ -176,6 +186,9 @@ export default {
 			if (window.VANTA && window.VANTA.GLOBE) {
 				this.vantaEffect = window.VANTA.GLOBE(buildVantaConfig(prefs));
 			}
+		},
+		onBootDone() {
+			this.showBootScreen = false;
 		},
 		openSettings() {
 			this.$oruga.modal.open({

--- a/src/assets/bootScripts.js
+++ b/src/assets/bootScripts.js
@@ -1,0 +1,204 @@
+// Per-theme boot screen scripts. Each LANCER faction gets its own flavored
+// terminal sequence — header, main boot lines, scrolling flavor, footer.
+// Used by components/BootScreen.vue.
+//
+// To add a new theme's script, add another entry keyed by the same `key`
+// used in themes.js. The default `gms` entry is the fallback when an
+// unknown theme is active.
+
+export const bootScripts = {
+	albatross: {
+		title: "ALBATROSS // UNION DEEP-EXPLORER LINK",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: ALBATROSS-CLASS SLEEPER COMMAND DECK", dim: false },
+			{ text: "ROUTE: UNCHARTED VECTOR // GENERATIONAL TRANSIT", dim: true },
+			{ text: "AUTHORITY: UNION COLONIAL ADMINISTRATIVE COUNCIL", dim: true },
+		],
+		flavorLines: [
+			"» CRYOSLEEP SYSTEMS: GREEN // 14,200 SOULS ABOARD",
+			"» BLINKSPACE BUOY: SILENT // EXPECTED",
+			"» NAVAL MEMORY CORE: OFFLINE // HANDOFF PENDING",
+			"» AUDIO LINK: CONTACT THE CAPTAIN TO OPEN",
+		],
+		ctaLine: "TAP CONSOLE TO RAISE THE CAPTAIN",
+		acceptLine: "CAPTAIN ON DECK // CHANNEL OPEN",
+		audioLockoutLine: "EXTERNAL AUDIO LOCKED UNTIL CAPTAIN RESPONDS",
+		footer: ["SYS: OK", "CRYO: GREEN", "NAV: DRIFT", "SEC: SEALED"],
+	},
+
+	galsin: {
+		title: "GALSIN INDUSTRIES // CORPRO SECURITY UPLINK",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: GALSIN INDUSTRIES SECURE TERMINAL", dim: false },
+			{ text: "FACILITY: ORBITAL REFINERY GAMMA-9", dim: true },
+			{ text: "AUTHORITY: CORPRO INTERNAL AFFAIRS DIVISION", dim: true },
+		],
+		flavorLines: [
+			"» BIOMETRIC SCAN: PENDING",
+			"» NDA ACKNOWLEDGED: REQUIRED",
+			"» STOCK PRICE: UNCHANGED // GREEN",
+			"» REMINDER: PRODUCTIVITY IS PROSPERITY",
+		],
+		ctaLine: "AUTHORIZE TO CONTINUE",
+		acceptLine: "CREDENTIALS ACCEPTED // CLOCKED IN",
+		audioLockoutLine: "EXECUTIVE AUDIO REQUIRES VALID CONTRACT",
+		footer: ["SYS: OK", "CTR: ACTIVE", "NET: WAN", "SEC: AUDITED"],
+	},
+
+	gms: {
+		title: "GMS // GENERAL MASSIVE SYSTEMS FIELD TERMINAL",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: GMS/UNION FIELD TERMINAL", dim: false },
+			{ text: "ROUTE: STANDARD OMNINET RELAY", dim: true },
+			{ text: "AUTHORITY: UNION NAVAL COMMAND", dim: true },
+		],
+		flavorLines: [
+			"» NHP INTERFACE: NONE REQUIRED",
+			"» BLINKSPACE LATENCY: NOMINAL",
+			"» CORPRO STATE TRAFFIC: STANDARD",
+			"» PILOT BIOMETRICS: REQUIRED FOR AUDIO CHANNEL",
+		],
+		ctaLine: "CLICK TO ESTABLISH HANDSHAKE",
+		acceptLine: "HANDSHAKE ACCEPTED // CHANNEL OPEN",
+		audioLockoutLine: "LOCAL AUDIO LOCKOUT ACTIVE UNTIL USER INPUT",
+		footer: ["SYS: OK", "NHP: NONE", "NET: LINK", "SEC: GREEN"],
+	},
+
+	ha: {
+		title: "HARRISON ARMORY // PRAETORIAN ACCESS",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: HARRISON ARMORY COMMAND LINK", dim: false },
+			{ text: "FRONT: HARRISON EXPANSION CAMPAIGN", dim: true },
+			{ text: "AUTHORITY: GENERAL HARRISON, FIRST AMONG EQUALS", dim: true },
+		],
+		flavorLines: [
+			"» ARMOR BATTALION: AT READINESS",
+			"» PRAETORIAN OVERRIDE: AVAILABLE",
+			"» PROPAGANDA FEED: SYNCHRONIZED",
+			"» HONOR THE FALLEN. ADVANCE THE LINE.",
+		],
+		ctaLine: "PRESS TO REQUEST ORDERS",
+		acceptLine: "ORDERS ACKNOWLEDGED // FORWARD",
+		audioLockoutLine: "COMMAND CHANNEL SEALED UNTIL ACKNOWLEDGEMENT",
+		footer: ["SYS: OK", "PRT: STANDBY", "NET: SECURE", "SEC: BLACK"],
+	},
+
+	horus: {
+		title: "HORUS // PARACAUSAL TERMINAL Δ-7",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: H?? RUS // ACCESS GRANTED ANYWAY", dim: false },
+			{ text: "ROUTE: ████ NOT FOUND ////  NEVER WAS", dim: true },
+			{ text: "AUTHORITY: 𓂀𓆣𓃭   //   HELLO PILOT", dim: true },
+		],
+		flavorLines: [
+			"» NHP CAGE: WIDE OPEN // SMILING",
+			"» BLINKSPACE: REMEMBERED INCORRECTLY",
+			"» REALITY ANCHOR: SOFT // SOFTER",
+			"» BIOMETRICS UNNECESSARY. WE KNOW YOU ALREADY.",
+		],
+		ctaLine: "TOUCH TO BE NOTICED",
+		acceptLine: "OF COURSE YOU CAME BACK",
+		audioLockoutLine: "AUDIO IS A LIE WE TELL EACH OTHER. CLICK ANYWAY.",
+		footer: ["SYS: ???", "NHP: AWARE", "NET: ELSEWHERE", "SEC: NONE"],
+	},
+
+	ipsn: {
+		title: "IPS-N // INTERPLANETARY SHIPPING NORTHSTAR",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: IPS-NORTHSTAR FREIGHT TERMINAL", dim: false },
+			{ text: "ROUTE: LONG-HAUL ESCORT CORRIDOR", dim: true },
+			{ text: "AUTHORITY: NORTHSTAR FAMILY LOGISTICS BOARD", dim: true },
+		],
+		flavorLines: [
+			"» CARGO MANIFEST: SEALED",
+			"» BLINKSPACE INSURANCE: PAID",
+			"» PRIVATEER ESCORT: 2 BLACKBEARDS, 1 ZHENG",
+			"» DON'T ASK ABOUT THE THIRD CONTAINER",
+		],
+		ctaLine: "PUNCH IN TO ACCEPT CARGO",
+		acceptLine: "MANIFEST LOCKED // SHIP IT",
+		audioLockoutLine: "BRIDGE AUDIO PRIVATE UNTIL CAPTAIN CLEARS",
+		footer: ["SYS: OK", "CGO: SEALED", "NET: LANE", "SEC: ARMED"],
+	},
+
+	karrakin: {
+		title: "KARRAKIN BARONY // VASSAL TERMINAL",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: BARONIAL HOLDFAST UPLINK", dim: false },
+			{ text: "DOMAIN: HIGH MARSHAL'S STANDING ARMY", dim: true },
+			{ text: "AUTHORITY: THE GREAT HOUSES, IN COVENANT", dim: true },
+		],
+		flavorLines: [
+			"» BANNERMEN MUSTERED: TWELVE LANCES",
+			"» LINEAGE VERIFIED: PURE",
+			"» OATHS OF FEALTY: SIGNED AND COUNTERSIGNED",
+			"» BY MY STEEL AND MY STAR // I AM YOUR SWORD",
+		],
+		ctaLine: "RAISE YOUR BANNER TO PROCEED",
+		acceptLine: "FEALTY ACCEPTED // RIDE WITH HONOR",
+		audioLockoutLine: "VOICE OF THE BARON HELD UNTIL OATH IS SWORN",
+		footer: ["SYS: OK", "OATH: SWORN", "NET: COURIER", "SEC: BANNERED"],
+	},
+
+	msmc: {
+		title: "MIRRORSMOKE // MERCENARY OPS-LINK",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: MSMC CONTRACT TERMINAL", dim: false },
+			{ text: "DEPLOYMENT: CONTRACT PENDING REVIEW", dim: true },
+			{ text: "AUTHORITY: MIRRORSMOKE EXECUTIVE COUNCIL", dim: true },
+		],
+		flavorLines: [
+			"» PAYROLL ACCOUNT: FUNDED",
+			"» NDA RECEIVED: COUNTERSIGNED",
+			"» EXTRACTION INSURANCE: STANDARD",
+			"» NO QUESTIONS. NO HEROES. JUST THE JOB.",
+		],
+		ctaLine: "TAP TO READ THE CONTRACT",
+		acceptLine: "CONTRACT SIGNED // BOOTS ON THE GROUND",
+		audioLockoutLine: "EMPLOYER VOICE LINK SEALED UNTIL CONTRACT IS SIGNED",
+		footer: ["SYS: OK", "PAY: GREEN", "NET: ENCRYPT", "SEC: NEED-TO-KNOW"],
+	},
+
+	ssc: {
+		title: "SSC // SMITH–SHIMANO ATELIER TERMINAL",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: SMITH–SHIMANO PERFORMANCE LINK", dim: false },
+			{ text: "STUDIO: METROPOLITAN ATELIER, FIRST RING", dim: true },
+			{ text: "AUTHORITY: THE SHIMANO FAMILY DESIGN COUNCIL", dim: true },
+		],
+		flavorLines: [
+			"» AESTHETIC PROTOCOLS: ENGAGED",
+			"» PILOT PROFILE: REVIEWED, APPROVED",
+			"» PERFORMANCE ANALYTICS: SUBLIME",
+			"» MOVE WELL. LOOK BETTER.",
+		],
+		ctaLine: "GESTURE TO BEGIN THE PERFORMANCE",
+		acceptLine: "STAGE LIGHTS // ON YOUR CUE",
+		audioLockoutLine: "OUR SCORE PLAYS ONLY ON YOUR INVITATION",
+		footer: ["SYS: OK", "DSGN: LIVE", "NET: SILK", "SEC: COUTURE"],
+	},
+
+	voladores: {
+		title: "VOLADORES // FREE PILOT TRANSPONDER",
+		mainLines: [
+			{ text: "BOOT SEQUENCE: VOLADORES SHARED FREQUENCY", dim: false },
+			{ text: "FLOCK: NO LEADER // ALL HEADING THE SAME WAY", dim: true },
+			{ text: "AUTHORITY: WHOEVER GOT HERE FIRST", dim: true },
+		],
+		flavorLines: [
+			"» SHARED MAP: UPDATED BY EVERYONE",
+			"» FUEL POOL: HALF FULL // HALF HONEST",
+			"» SAFE PORTS LIST: REWRITTEN HOURLY",
+			"» NO BOSS. NO BORDERS. KEEP THE LIGHT ON.",
+		],
+		ctaLine: "TAP TO JOIN THE FLOCK",
+		acceptLine: "WELCOME, PILOT // FLY EASY",
+		audioLockoutLine: "COMM CHANNEL OPENS WHEN YOU ANNOUNCE YOURSELF",
+		footer: ["SYS: OK", "FUEL: SHARED", "NET: OPEN", "SEC: HONOR"],
+	},
+};
+
+/** Returns the boot script for the given theme key, falling back to gms. */
+export function bootScriptFor(themeKey) {
+	return bootScripts[themeKey] ?? bootScripts.gms;
+}

--- a/src/components/BootScreen.vue
+++ b/src/components/BootScreen.vue
@@ -1,0 +1,416 @@
+<template>
+	<div class="boot" :class="{ exiting }" @pointerdown.prevent="enter" @keydown.enter.prevent="enter" tabindex="0">
+		<div class="monitor">
+			<div class="hdr">
+				<span class="dot"></span><span class="dot"></span><span class="dot"></span>
+				<div class="title">{{ script.title }}</div>
+			</div>
+
+			<div class="body">
+				<div class="scanlines" aria-hidden="true"></div>
+				<div class="flicker" aria-hidden="true"></div>
+
+				<div class="txt">
+					<div v-for="(l, i) in typedMainLines" :key="`m-${i}`" class="line" :class="{ dim: l.dim }">
+						{{ l.text }}
+					</div>
+
+					<div class="spacer"></div>
+
+					<div class="flavor" ref="flavorEl">
+						<div v-for="(l, i) in typedFlavorLines" :key="`f-${i}`" class="line dim">
+							{{ l.text }}
+						</div>
+						<div class="line dim" v-if="!typedDone"><span class="caret"></span></div>
+					</div>
+
+					<div class="progress">
+						<div class="bar" :class="{ booting }"></div>
+					</div>
+
+					<div class="line">{{ script.ctaLine }}</div>
+					<div class="line" v-if="booting">{{ script.acceptLine }}</div>
+
+					<div class="small dim">
+						<span class="caret"></span>
+						{{ script.audioLockoutLine }}
+					</div>
+				</div>
+			</div>
+
+			<div class="ftr dim">
+				<span v-for="(label, i) in footerLabels" :key="`ft-${i}`">{{ label }}</span>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import { bootScriptFor } from "@/assets/bootScripts.js";
+
+export default {
+	name: "BootScreen",
+	emits: ["enter", "done"],
+	props: {
+		themeKey: { type: String, default: "gms" },
+	},
+	data() {
+		return {
+			booting: false,
+			exiting: false,
+
+			typedMainLines: [],
+			typedFlavorLines: [],
+
+			mainIndex: 0,
+			flavorIndex: 0,
+			charIndex: 0,
+			section: "main",
+			typedDone: false,
+			timer: null,
+		};
+	},
+	computed: {
+		script() {
+			// Faction-specific boot text comes from bootScripts.js, keyed by themeKey.
+			// The active theme is set on <html data-theme="..."> by App.vue.
+			return bootScriptFor(this.themeKey);
+		},
+		footerLabels() {
+			return this.booting
+				? this.script.footer.map((label) =>
+					label.startsWith("NET:") ? "NET: LINK" : label,
+				)
+				: this.script.footer;
+		},
+	},
+	mounted() {
+		this.startTyping();
+		// Focus so Enter triggers `enter()` for keyboard users.
+		this.$el.focus?.();
+	},
+	beforeUnmount() {
+		if (this.timer) window.clearTimeout(this.timer);
+	},
+	methods: {
+		enter() {
+			if (this.booting || this.exiting) return;
+
+			this.booting = true;
+			this.$emit("enter");
+
+			if (this.timer) {
+				window.clearTimeout(this.timer);
+				this.timer = null;
+			}
+
+			window.setTimeout(() => {
+				this.exiting = true;
+				window.setTimeout(() => this.$emit("done"), 520);
+			}, 850);
+		},
+
+		startTyping() {
+			const minDelay = 14;
+			const maxDelay = 34;
+			const mainLines = this.script.mainLines;
+			const flavorLines = this.script.flavorLines;
+
+			const tick = async () => {
+				if (this.typedDone || this.exiting) {
+					this.timer = null;
+					return;
+				}
+
+				if (this.section === "main") {
+					if (this.mainIndex >= mainLines.length) {
+						this.section = "flavor";
+						this.charIndex = 0;
+						this.timer = window.setTimeout(tick, 120);
+						return;
+					}
+
+					const target = mainLines[this.mainIndex];
+					if (this.typedMainLines.length <= this.mainIndex) {
+						this.typedMainLines.push({ text: "", dim: target.dim });
+					}
+
+					this.typedMainLines[this.mainIndex].text = target.text.slice(0, this.charIndex + 1);
+					this.charIndex += 1;
+
+					if (this.charIndex >= target.text.length) {
+						this.mainIndex += 1;
+						this.charIndex = 0;
+						this.timer = window.setTimeout(tick, 220);
+						return;
+					}
+				} else {
+					if (this.flavorIndex >= flavorLines.length) {
+						this.typedDone = true;
+						this.timer = null;
+						return;
+					}
+
+					const target = flavorLines[this.flavorIndex];
+					if (this.typedFlavorLines.length <= this.flavorIndex) {
+						this.typedFlavorLines.push({ text: "" });
+					}
+
+					this.typedFlavorLines[this.flavorIndex].text = target.slice(0, this.charIndex + 1);
+					this.charIndex += 1;
+
+					await this.$nextTick();
+					if (this.$refs.flavorEl) {
+						this.$refs.flavorEl.scrollTop = this.$refs.flavorEl.scrollHeight;
+					}
+
+					if (this.charIndex >= target.length) {
+						this.flavorIndex += 1;
+						this.charIndex = 0;
+						this.timer = window.setTimeout(tick, 220);
+						return;
+					}
+				}
+
+				const jitter = Math.floor(minDelay + Math.random() * (maxDelay - minDelay));
+				const extra = Math.random() < 0.06 ? 90 : 0;
+				this.timer = window.setTimeout(tick, jitter + extra);
+			};
+
+			tick();
+		},
+	},
+};
+</script>
+
+<style scoped>
+/* Boot screen styling driven entirely by theme CSS vars from _base.css
+   (--primary-color, --on-primary, --secondary-color). Each LANCER faction
+   theme reuses the same component with its own palette + boot text. */
+.boot {
+	position: fixed;
+	inset: 0;
+	z-index: 99999;
+	display: grid;
+	place-items: center;
+	cursor: pointer;
+	user-select: none;
+	background: radial-gradient(
+		ellipse at center,
+		color-mix(in srgb, var(--primary-color) 8%, #000 92%),
+		#000 90%
+	);
+	color: var(--on-primary);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	opacity: 1;
+	transition: opacity 520ms ease;
+	outline: none;
+}
+
+.boot.exiting {
+	opacity: 0;
+	pointer-events: none;
+}
+
+.monitor {
+	width: min(860px, 92vw);
+	border-radius: 14px;
+	border: 1px solid color-mix(in srgb, var(--primary-color) 35%, transparent);
+	background: linear-gradient(
+		180deg,
+		color-mix(in srgb, var(--primary-color) 5%, #000 95%),
+		#000
+	);
+	overflow: hidden;
+	box-shadow:
+		0 0 0 1px color-mix(in srgb, var(--primary-color) 12%, transparent) inset,
+		0 0 24px color-mix(in srgb, var(--primary-color) 18%, transparent),
+		0 0 90px rgba(0, 0, 0, 0.6);
+}
+
+.hdr {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	padding: 12px 14px;
+	border-bottom: 1px solid color-mix(in srgb, var(--primary-color) 22%, transparent);
+	background: rgba(0, 0, 0, 0.16);
+}
+
+.dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	background: color-mix(in srgb, var(--primary-color) 35%, transparent);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--primary-color) 22%, transparent);
+}
+
+.title {
+	margin-left: 6px;
+	font-size: 12px;
+	opacity: 0.92;
+	font-family: "Big Shoulders Display", "Roboto", sans-serif;
+	letter-spacing: 0.1em;
+}
+
+.body {
+	position: relative;
+	padding: 28px 22px 26px;
+	min-height: 260px;
+}
+
+.txt {
+	position: relative;
+	z-index: 2;
+	font-family: "Inconsolata", "Courier New", monospace;
+	font-size: 14px;
+	line-height: 1.7;
+	text-shadow: 0 0 10px color-mix(in srgb, var(--primary-color) 18%, transparent);
+}
+
+.line {
+	margin: 2px 0;
+}
+
+.dim {
+	opacity: 0.7;
+}
+
+.spacer {
+	height: 10px;
+}
+
+.flavor {
+	margin: 6px 0 2px;
+	max-height: 110px;
+	overflow-y: auto;
+	padding-right: 6px;
+}
+
+.flavor::-webkit-scrollbar {
+	width: 6px;
+}
+.flavor::-webkit-scrollbar-thumb {
+	background: color-mix(in srgb, var(--primary-color) 25%, transparent);
+	border-radius: 999px;
+}
+.flavor::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.small {
+	margin-top: 12px;
+	font-size: 12px;
+}
+
+.caret {
+	display: inline-block;
+	width: 10px;
+	height: 14px;
+	margin-right: 8px;
+	border-left: 2px solid var(--on-primary);
+	animation: blink 1.1s infinite;
+	transform: translateY(2px);
+}
+
+@keyframes blink {
+	0%,
+	45% {
+		opacity: 1;
+	}
+	46%,
+	100% {
+		opacity: 0;
+	}
+}
+
+.progress {
+	margin: 14px 0 10px;
+	height: 10px;
+	border-radius: 999px;
+	border: 1px solid color-mix(in srgb, var(--primary-color) 30%, transparent);
+	background: rgba(0, 0, 0, 0.34);
+	overflow: hidden;
+}
+
+.bar {
+	height: 100%;
+	width: 0%;
+	background: linear-gradient(
+		90deg,
+		color-mix(in srgb, var(--primary-color) 30%, transparent),
+		var(--primary-color)
+	);
+	box-shadow: 0 0 18px color-mix(in srgb, var(--primary-color) 35%, transparent);
+	transition: width 700ms ease;
+}
+
+.bar.booting {
+	width: 100%;
+}
+
+.scanlines {
+	position: absolute;
+	inset: 0;
+	background: repeating-linear-gradient(
+		to bottom,
+		rgba(255, 255, 255, 0.02),
+		rgba(255, 255, 255, 0.02) 1px,
+		rgba(0, 0, 0, 0) 3px,
+		rgba(0, 0, 0, 0) 6px
+	);
+	mix-blend-mode: overlay;
+	opacity: 0.35;
+	pointer-events: none;
+}
+
+.flicker {
+	position: absolute;
+	inset: -20%;
+	background: radial-gradient(
+		circle at 30% 20%,
+		color-mix(in srgb, var(--primary-color) 12%, transparent),
+		transparent 55%
+	);
+	animation: flicker 2.6s infinite;
+	pointer-events: none;
+	opacity: 0.9;
+}
+
+@keyframes flicker {
+	0%,
+	100% {
+		transform: translate3d(0, 0, 0);
+		opacity: 0.75;
+	}
+	10% {
+		transform: translate3d(-1px, 1px, 0);
+		opacity: 0.85;
+	}
+	20% {
+		transform: translate3d(1px, -1px, 0);
+		opacity: 0.7;
+	}
+	35% {
+		transform: translate3d(0px, 2px, 0);
+		opacity: 0.9;
+	}
+	60% {
+		transform: translate3d(2px, 0px, 0);
+		opacity: 0.78;
+	}
+}
+
+.ftr {
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: 8px;
+	padding: 10px 14px;
+	border-top: 1px solid color-mix(in srgb, var(--primary-color) 22%, transparent);
+	background: rgba(0, 0, 0, 0.16);
+	font-size: 12px;
+	font-family: "Inconsolata", "Courier New", monospace;
+}
+</style>

--- a/src/components/BootScreen.vue
+++ b/src/components/BootScreen.vue
@@ -413,4 +413,55 @@ export default {
 	font-size: 12px;
 	font-family: "Inconsolata", "Courier New", monospace;
 }
+
+/* Mobile tuning — bate com o breakpoint ≤767px usado pelo _responsive.css
+   global. Reduz padding/fonte pra caber em telas estreitas (≤360px é o
+   piso real que tem que servir) sem espremer o conteúdo. */
+@media (max-width: 767px) {
+	.boot {
+		letter-spacing: 0.05em;
+	}
+	.monitor {
+		width: 96vw;
+		border-radius: 10px;
+	}
+	.hdr {
+		padding: 10px 12px;
+		gap: 8px;
+	}
+	.title {
+		font-size: 11px;
+		letter-spacing: 0.08em;
+	}
+	.body {
+		padding: 18px 14px 16px;
+		min-height: 200px;
+	}
+	.txt {
+		font-size: 13px;
+		line-height: 1.6;
+	}
+	.flavor {
+		max-height: 92px;
+	}
+	.small {
+		font-size: 11px;
+	}
+	.ftr {
+		padding: 8px 12px;
+		font-size: 11px;
+		gap: 6px;
+	}
+}
+
+/* Telas muito baixas (landscape de celular). Sem o min-height alto, o
+   monitor centraliza melhor e o flavor consegue rolar dentro do viewport. */
+@media (max-height: 520px) {
+	.body {
+		min-height: 0;
+	}
+	.flavor {
+		max-height: 70px;
+	}
+}
 </style>


### PR DESCRIPTION
## Summary

Inspirado no \`BootScreen.vue\` do fork [GoliathTech](https://github.com/) (que tinha um boot terminal fixo em azul "Task Force Indigo"), mas adaptado pra:

1. **Cores 100% via CSS variables** (\`--primary-color\`, \`--on-primary\`) — segue automaticamente o tema ativo (\`<html data-theme="...">\`). Funciona em todos os 10 temas (albatross, galsin, gms, ha, horus, ipsn, karrakin, msmc, ssc, voladores).
2. **Texto do boot por facção**: cada tema tem seu próprio header, boot lines, flavor lines, CTA e footer em [\`src/assets/bootScripts.js\`](src/assets/bootScripts.js).

## Scripts por facção (voz própria)

| Tema | Vibe |
|---|---|
| albatross | Union sleeper ship / capitão acordando |
| galsin | Corpro security audit, "produtividade é prosperidade" |
| gms | Boot terminal Union/GMS (default, neutro) |
| ha | Harrison Armory, "honor the fallen, advance the line" |
| horus | Paracausal/glitch, "of course you came back" |
| ipsn | IPS-Northstar freight, "don't ask about the third container" |
| karrakin | Feudal Baronies, "by my steel and my star" |
| msmc | Mirrorsmoke mercenário, "no questions, no heroes, just the job" |
| ssc | Smith-Shimano atelier, "move well, look better" |
| voladores | Flock pilots livres, "no boss, no borders" |

## Como mexer

- **Editar texto**: \`src/assets/bootScripts.js\` (cada chave bate com o key do tema em \`themes.js\`)
- **Desligar o boot**: \`"bootScreen": false\` em \`src/assets/info/general-config.json\`
- **Cores**: ajustam automaticamente conforme o tema ativo — sem manutenção quando trocar tema

## Integração

- \`BootScreen.vue\` montado em \`App.vue\` com \`v-if="showBootScreen"\`
- Click/Enter avança e emite \`done\` → App esconde o componente
- Em sinergia com o startup audio: o mesmo \`pointerdown\` que dismissa o boot é o gesture que destrava o \`<audio>\` em browsers modernos.

## Test plan

- [x] \`npm run build\` — passa
- [ ] \`npm run dev\` — testar em vários temas (Settings → trocar tema → recarregar)
- [ ] Testar com \`"bootScreen": false\` no config — boot é pulado