### PR TITLE
fix(squad-modal): proper styling + LL label

### DIFF
--- a/src/components/modals/SquadModal.vue
+++ b/src/components/modals/SquadModal.vue
@@ -3,33 +3,39 @@
 		<div class="squad-header-container">
 			<div class="section-header clipped-medium-backward-bio">
 				<img src="/icons/squad.svg" />
-				<h1>{{ squad.name.toUpperCase() }}</h1>
+				<h2>{{ squad.name.toUpperCase() }}</h2>
 			</div>
 			<div class="rhombus-back">&nbsp;</div>
 		</div>
-		<div class="squad-meta-bar">
-			<span class="subtitle">{{ squad.pilots.length }} PILOTO{{ squad.pilots.length === 1 ? '' : 'S' }} REGISTRADO{{ squad.pilots.length === 1 ? '' : 'S' }}</span>
-		</div>
-		<div class="squad-scroll">
-			<div class="squad-members-grid">
-				<div
-					v-for="pilot in squad.pilots"
-					:key="pilot.callsign"
-					class="member-card"
-				>
-					<div class="member-header">
-						<img :src="`/pilots/${pilot.callsign.toUpperCase()}.webp`" class="member-portrait" @error="onMissingPortrait" />
-						<div>
-							<h3>{{ pilot.callsign.toUpperCase() }}</h3>
-							<p class="name-line">{{ pilot.name }}</p>
+
+		<div class="squad-body">
+			<div class="squad-meta-bar">
+				<span class="subtitle">
+					{{ squad.pilots.length }} PILOTO{{ squad.pilots.length === 1 ? '' : 'S' }} REGISTRADO{{ squad.pilots.length === 1 ? '' : 'S' }}
+				</span>
+			</div>
+
+			<div class="squad-scroll">
+				<div class="squad-members-grid">
+					<div
+						v-for="pilot in squad.pilots"
+						:key="pilot.callsign"
+						class="member-card"
+					>
+						<div class="member-header">
+							<img :src="`/pilots/${pilot.callsign.toUpperCase()}.webp`" class="member-portrait" @error="onMissingPortrait" />
+							<div>
+								<h3>{{ pilot.callsign.toUpperCase() }}</h3>
+								<p class="name-line">{{ pilot.name }}</p>
+							</div>
 						</div>
-					</div>
-					<div class="member-body">
-						<p><strong>Status:</strong> {{ pilot.status || 'Active' }}</p>
-						<p><strong>Background:</strong> {{ pilot.background || 'Unknown' }}</p>
-						<p><strong>Nível:</strong> {{ pilot.level }}</p>
-						<p v-if="pilot.role"><strong>Função:</strong> {{ pilot.role }}</p>
-						<p v-if="activeMechName(pilot)"><strong>Mech ativo:</strong> {{ activeMechName(pilot) }}</p>
+						<div class="member-body">
+							<p><strong>Status:</strong> {{ pilot.status || 'Active' }}</p>
+							<p><strong>Background:</strong> {{ pilot.background || 'Unknown' }}</p>
+							<p><strong>LL:</strong> {{ pilot.level }}</p>
+							<p v-if="pilot.role"><strong>Função:</strong> {{ pilot.role }}</p>
+							<p v-if="activeMechName(pilot)"><strong>Mech ativo:</strong> {{ activeMechName(pilot) }}</p>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -58,17 +64,73 @@ export default {
 </script>
 
 <style scoped>
+/* Layout reproduz o padrão visual do PilotModal — header bar primary +
+   rhombus skewed, body branco/secundário com borda primary. As classes
+   utilitárias (section-header, clipped-medium-backward-bio) vêm dos estilos
+   globais; aqui só constrainho o que é específico do squad (ícone, body
+   width, member grid). */
 .squad-modal {
-	background: var(--secondary-color);
+	position: relative;
+	width: min(1100px, 92vw);
+}
+
+.squad-header-container {
+	display: flex;
+}
+
+.squad-modal .section-header {
+	background-color: var(--primary-color);
+	border-color: var(--primary-color);
+	height: 52px;
+	display: inline-flex;
+	gap: 15px;
+	padding-left: 16px;
+	margin-top: -38px;
+	align-items: center;
+}
+
+.squad-modal .section-header img {
+	width: 28px;
+	height: 28px;
+	filter: var(--icon-color);
+}
+
+.squad-modal .section-header h2 {
+	margin: 0;
+	font-family: "Big Shoulders Display", cursive;
+	font-weight: 800;
+	font-size: 26px;
+	letter-spacing: 0.1em;
+	color: var(--on-primary);
+	text-transform: uppercase;
+}
+
+.squad-modal .rhombus-back {
+	transform: skew(0.785398rad);
+	background-color: var(--primary-color);
+	border-color: var(--primary-color);
+	width: 40px;
+	height: 52px;
+	display: inline-block;
+	position: relative;
+	left: -10px;
+	top: -38px;
+}
+
+.squad-body {
+	background-color: var(--secondary-color);
+	border: 1px solid var(--primary-color);
+	margin-top: -38px;
 	color: var(--text-pilot-value);
-	max-width: 1600px;
-	min-height: 80vh;
-	padding-bottom: 1rem;
 	font-family: "Titillium Web", sans-serif;
+	min-height: 60vh;
+	max-height: 80vh;
+	display: flex;
+	flex-direction: column;
 }
 
 .squad-meta-bar {
-	padding: 0.5rem 1.5rem 1rem;
+	padding: 0.6rem 1.5rem;
 	border-bottom: 1px solid var(--location-separator);
 }
 
@@ -79,14 +141,14 @@ export default {
 }
 
 .squad-scroll {
-	max-height: calc(80vh - 200px);
+	flex: 1;
 	overflow-y: auto;
 	padding: 1rem 1.5rem;
 }
 
 .squad-members-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+	grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
 	gap: 1rem;
 }
 
@@ -139,5 +201,31 @@ export default {
 .member-body strong {
 	color: var(--primary-color);
 	margin-right: 0.4rem;
+}
+
+/* Mobile tuning — fonte/padding menores, grade vira coluna única em
+   telas estreitas, e o body pode usar a viewport quase toda. */
+@media (max-width: 767px) {
+	.squad-modal {
+		width: 96vw;
+	}
+	.squad-modal .section-header h2 {
+		font-size: 20px;
+		letter-spacing: 0.06em;
+	}
+	.squad-modal .section-header img {
+		width: 22px;
+		height: 22px;
+	}
+	.squad-members-grid {
+		grid-template-columns: 1fr;
+	}
+	.member-portrait {
+		width: 52px;
+		height: 52px;
+	}
+	.member-header h3 {
+		font-size: 1.2rem;
+	}
 }
 </style>


### PR DESCRIPTION
## Summary

Dois problemas no SquadModal que ficaram do PR #30:

### 1. Tela ficava "escura" ao abrir o squad

Causa: o \`.section-header\` e o body do modal não tinham styling. As regras do PilotModal estão em \`_base.css\` mas com prefixo \`.pilot-modal\`, então o \`.squad-modal\` herdava nada. Resultado:

- O ícone \`squad.svg\` renderizava no tamanho intrínseco (cluster grande de dots no centro da modal).
- O body não tinha background sólido → o backdrop preto do Oruga dominava a tela.

Fix: reproduz o padrão visual do PilotModal escopado em \`.squad-modal\` (header bar com \`--primary-color\`, rhombus skewed, body com \`--secondary-color\` e borda primary). Ícone constrained a 28×28 com filter \`--icon-color\` pra seguir o tema.

### 2. "Nível" → "LL"

LL é o termo canônico do LANCER (Lancer's License level). Trocado em \`member.body\` (foi a única label que precisava).

## Bonus

- Mobile breakpoint: grid de membros vira coluna única em ≤767px, fontes/portraits menores.
- Body usa flexbox com \`max-height: 80vh\` → scroll fica na grade de membros, não na modal inteira.

## Test plan

- [x] \`npm run build\` — passa
- [ ] \`npm run dev\` → /squads → clicar em BAD JUJU → verificar header vermelho + body branco + LL: 0 em vez de Nível: 0