### PR TITLE
fix(css): use valid border shorthand for .person border-bottom

### DIFF
--- a/src/assets/styles/_base.css
+++ b/src/assets/styles/_base.css
@@ -1351,7 +1351,7 @@ section .section-header h2 {
 }
 
 .person-list-container .person {
-	border-bottom: var(--primary 1px solid);
+	border-bottom: 1px solid var(--primary-color);
 }
 
 .person-list-container .person:last-child {


### PR DESCRIPTION
## Problema
A linha em `src/assets/styles/_base.css` usava:
```css
border-bottom: var(--primary 1px solid);
```
Isso é CSS inválido — `var()` malformado e a variável `--primary` não existe (o projeto usa `--primary-color`). O minificador mais recente do vite/lightningcss (introduzido pelo bump de segurança do esbuild/vite no #37) passou a rejeitar isso, quebrando o build de produção.

## Correção
Substituído pela convenção já usada no resto do arquivo (linhas 682, 735, 785, 1179):
```css
border-bottom: 1px solid var(--primary-color);
```

## Validação
`npm run build` passa localmente. Isso desbloqueia o PR de segurança #37 (esbuild/vite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)