### PR TITLE
fix: move ship name to subheader row so the title doesn't wrap

### DIFF
--- a/src/assets/info/general-config.json
+++ b/src/assets/info/general-config.json
@@ -11,8 +11,8 @@
     "gate": "Nova Elísia",
     "ring": "AEL",
     "headerTitle": "Departamento Naval da União",
-    "headerSubtitle": "NMU-PN Rio Grande",
-    "subheaderTitle": "Esquadrão",
+    "headerSubtitle": "",
+    "subheaderTitle": "NMU-PN Rio Grande",
     "subheaderSubtitle": "Rei Pescador"
   },
   "pilotSpecialInfo": {}


### PR DESCRIPTION
headerSubtitle shares the first title row — a non-empty value concatenates
after the title and wraps badly. Keep it empty (as the guide config did)
and render "NMU-PN Rio Grande // Rei Pescador" on the second row.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
