### PR TITLE
Corrige Event Log transbordando a viewport (1200-1322px)

### DIFF
--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -491,6 +491,32 @@ body > canvas {
 }
 
 /* ============================================
+   EventsView dead zone (1200–1322px)
+   The desktop side-by-side needs events (393) + margins (60) +
+   events-logs (min 600) + margins (180) + sidebar (90) = 1323px to
+   fit. #router-view-container is absolutely positioned (left: 90px,
+   no width), so below 1323px the min-width:600 log overflows the
+   viewport with no scroll. The ≤1199 stacking rule doesn't reach here,
+   so stack the two panels in this band too — width is viewport-based
+   because the absolute parent has no width to take 100% from.
+   ============================================ */
+@media (min-width: 1200px) and (max-width: 1322px) {
+	#eventsView.content-container {
+		flex-direction: column;
+	}
+
+	section.section-container#events,
+	section.section-container#events-logs {
+		width: calc(100vw - 90px - 40px);
+		max-width: calc(100vw - 90px - 40px);
+		min-width: 0;
+		margin: 20px;
+		height: auto;
+		box-sizing: border-box;
+	}
+}
+
+/* ============================================
    MOBILE (max 767px)
    Full reflow: horizontal sidebar, stacked everything
    ============================================ */


### PR DESCRIPTION
## Problema
Em telas de ~1200–1322px de largura CSS, o painel **Event Log** (em /events) transbordava a borda direita da viewport e o texto era cortado, sem barra de rolagem. (Visto em contralancer.netlify.app/events.)

## Causa
`#router-view-container` é `position: absolute; left: 90px` **sem largura/right**, então nada limita a linha do EventsView. O layout lado-a-lado só cabe a partir de **1323px**: sidebar (90) + events (393) + margens (60) + events-logs (min 600) + margens (180). A regra de empilhamento existente vai só até 1199px, então na faixa **1200–1322px** o `min-width: 600px` do log estourava a viewport (e, por ser absoluto, sem scroll).

## Correção
Media query dedicada `(min-width: 1200px) and (max-width: 1322px)` que empilha os dois painéis nessa faixa (como já ocorre abaixo de 1200), com largura baseada na viewport (`100vw - 90 - 40`), já que o pai absoluto não tem largura para `100%`. Acima de 1323px o lado-a-lado volta e encaixa exato.

## Verificação
- `npm run build` ✓ · prettier ✓
- Conferência de layout: a 1210px cada painel = 1080px cabendo em 1120px disponíveis; handoff em 1323px é contínuo (events-logs = 600px exatos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)