### PR TITLE
Corrige overflow das views em telas 1600-1919px

### DIFF
--- a/src/assets/styles/_responsive.css
+++ b/src/assets/styles/_responsive.css
@@ -34,7 +34,7 @@ body > canvas {
    ALL VIEWPORTS < 1600px
    Allow vertical scroll, prevent horizontal overflow
    ============================================ */
-@media (max-width: 1599px) {
+@media (max-width: 1919px) {
 	#app {
 		overflow-x: hidden !important;
 		overflow-y: auto !important;
@@ -103,11 +103,15 @@ body > canvas {
 }
 
 /* ============================================
-   SMALL DESKTOP (1024px – 1599px)
-   Scale wide sections + wrap StatusView so iPad Pro
-   (1024 portrait / 1366 landscape) doesn't hide modules
+   SMALL DESKTOP (1024px – 1919px)
+   Scale wide sections + wrap StatusView so laptops/iPad Pro
+   (1024 portrait / 1366 landscape / 1680 HiDPI) don't overflow.
+   The fixed-width base layout only fits at ≥1920px (events row
+   needs ~1902px); below that, #router-view-container is absolutely
+   positioned with no width, so the fixed columns run off the
+   viewport. Keep the flexible/wrapping layout up to 1919px.
    ============================================ */
-@media (max-width: 1599px) {
+@media (max-width: 1919px) {
 	section.section-container#pilots {
 		width: calc(100vw - 90px - 60px);
 		max-width: 1755px;


### PR DESCRIPTION
## Problema
Em /events e /status, as colunas da direita (Event Log; Reservas/Contadores) eram cortadas na borda da viewport em telas de **1600–1919px** de largura CSS — o caso do MacBook 3360×2100 @ 2× (≈1680px CSS).

## Causa
O bloco "SMALL DESKTOP" com os layouts flexíveis (events-logs com largura por `calc`, StatusView com `flex-wrap`, #pilots escalável) era limitado a `max-width: 1599px`. Acima disso, os views voltavam às larguras fixas grandes (events-logs 1179px; status em 3 colunas fixas), que só cabem a partir de **1920px**. Como `#router-view-container` é `position: absolute` sem largura, nada segura o conteúdo — e em 1600–1919px as colunas transbordavam sem scroll.

## Correção
Subi o breakpoint do bloco flexível de 1599 para **1919px** (e o `overflow-x: hidden` do #app junto). Assim o layout flexível cobre 1024–1919px e o layout fixo grande só entra a partir de 1920px, onde de fato cabe. Complementa o fix da faixa 1200–1322px (#44).

## Verificação
- `npm run build` ✓ · prettier ✓
- Layout a 1680px: linha de eventos = 90+60+393+180+957 = 1680 (cabe exato); status quebra em linhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)