### PR TITLE
Arte do livro inline nos textos de missão/eventos

### DIFF
--- a/src/assets/events/000.md
+++ b/src/assets/events/000.md
@@ -19,6 +19,8 @@ A **Operação Chuva de Solstício** começa em meio a esse processo: a terceira
 
 AEL e Soberania travam uma **guerra fria** que remonta a décadas, herança dos Anos Estéreis. A presença da União, a pedido da AEL, tem exacerbado essas tensões — mas ainda não chegou ao ponto de guerra declarada.
 
+![Nova Elísia à noite, vista do Posto Avançado Sabre](/uploads/nova-elisia-noite.jpg)
+
 ## TECNOLOGIA
 
 Apesar do longo isolamento, Cressidium acompanhou em geral as tendências galácticas. Suas nações desenvolveram mechas próprios — comparáveis aos de outras regiões, ainda que por evolução divergente. As maiores diferenças estão na compreensão limitada da ciência paracausal e na perda das impressoras coloniais originais, deixando a produção dependente de manufatura convencional. Capacidade espacial restrita: elevadores espaciais e naves de superfície equivalentes a corvetas, usadas sobretudo como dissuasão.

--- a/src/assets/events/001.md
+++ b/src/assets/events/001.md
@@ -13,12 +13,18 @@ Vocês foram destacados para a Rio Grande logo após se formarem na academia. Es
 
 ## PESSOAS DE INTERESSE
 
+![Capitã Brigid Farris](/uploads/npc-farris.png)
+
 **Capitã Brigid Farris** *(ela/dela)* — Oficial de carreira, 20 anos de serviço subjetivo, 10 deles no comando da Rio Grande. Confiante, equilibrada sob pressão, respeitada pela tripulação. Gosta de contar histórias da padaria da família; concursos improvisados de confeitaria viraram tradição nas folgas. Esta é sua primeira missão de recontato, e ela quer que termine bem — de forma pacífica — para todos.
+
+![Primeiro-Tenente Alex Kim](/uploads/npc-kim.png)
 
 **Primeiro-Tenente Alex Kim** *(ele/dele)* — Imediato, promovido há relativamente pouco tempo e ansioso para provar seu valor (ansioso demais, dizem alguns, após mais um discurso motivacional). Olhar atento aos detalhes e domínio de táticas; campeão incontestável da nave no jogo de cartas Kapkat. Com a capitã em terra, **o comando é dele.**
 
 **Rio, PNH de bordo** *(ela/dela)* — A personalidade paracausal da classe TÁLASSA da nave: extrovertida, alegre, com queda por dramas da omninet e uma das poucas parceiras de xadrez que o 1º Ten. Kim aprecia. Em combate, adota sua "cara de jogo": coordena defesas de ponto, contramedidas, subalternos robóticos e as alas de caças e mechas.
 
 **Terceiro-Sargento Omari Garcia** *(ele/dele)* — Fuzileiro durão e teimoso, orgulhoso da velha rivalidade fraternal com os pilotos de mecha ("ternos chiques"). Condecorado com a Medalha de Serviço Distinto dos Fuzileiros pela Disputa de Pellaran. Ferozmente leal: o primeiro a entrar no perigo e o último a sair. Gosta de pescar e de armas de fogo antigas.
+
+![Embaixador Nilan Bannerjee](/uploads/npc-bannerjee.png)
 
 **Embaixador Nilan Bannerjee** *(elu/delu)* — Representante do Departamento Administrativo da União na missão. Décadas construindo pontes entre povos e nações. Carismático, poliglota, de humor seco e rosto impenetrável. Sereno mesmo sob pressão — e a pressão aqui é alta: um acordo entre AEL e Soberania encerraria décadas de tensão e afastaria a ameaça de guerra total. Viajou em sua própria nave, mas visita a Rio Grande periodicamente para reuniões com os oficiais.

--- a/src/assets/missions/001.md
+++ b/src/assets/missions/001.md
@@ -18,6 +18,8 @@ status: start
 
 Imagens de passagem orbital coletadas por Rio indicam que **Nova Elísia está sob ataque de forças da Soberania Vestana**, com uma mobilização significativa de chassis mecanizados pela cidade. Cressidium não é oficialmente um membro da União; a Marinha **não está autorizada a intervir** no conflito em apoio à AEL. Mas deixar a Capitã Farris e o Embaixador Bannerjee para se virarem sozinhos não é uma opção.
 
+![Chassis vestanos avançando por Nova Elísia — captura de passagem orbital](/uploads/combate-urbano.jpg)
+
 Reunidos os oficiais, foi decidido conduzir uma operação de resgate. O Esquadrão Rei Pescador foi selecionado para descer com a **primeira leva** e assegurar a área.
 
 ### OBJETIVO DA MISSÃO

--- a/src/assets/styles/_base.css
+++ b/src/assets/styles/_base.css
@@ -1540,6 +1540,18 @@ div.markdown p {
 	margin: 1em 0;
 }
 
+/* Inline art dropped into mission/event bodies (NPC portraits, recon
+   shots). Never wider than the column; framed to match the section
+   chrome. Portrait cutouts from the book come on flat dark plates, so
+   the frame reads as a dossier photo. */
+div.markdown img {
+	display: block;
+	max-width: min(360px, 100%);
+	height: auto;
+	margin: 1em auto;
+	border: 1px solid var(--primary-color);
+}
+
 div.markdown hr {
 	border-color: var(--primary-color);
 }


### PR DESCRIPTION
## Resumo
- **Vida a Bordo**: retratos da Capitã Farris, do 1º Ten. Kim e do Embaixador Bannerjee junto aos seus parágrafos em Pessoas de Interesse (Rio e Garcia não têm retrato no livro).
- **Cressidium em Resumo**: vista noturna de Nova Elísia (PA Sabre) após a seção das potências.
- **Missão 001**: chassis vestanos avançando pela cidade, enquadrado como captura da passagem orbital citada no texto.
- Nova regra `div.markdown img` (máx. 360px, centralizada, moldura na cor primária) — antes não havia estilo para imagens no markdown e elas estourariam o modal.

## Verificação
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)