### PR TITLE
Boot dispensa mais rápido — menu clicável de imediato

### DIFF
--- a/src/components/BootScreen.vue
+++ b/src/components/BootScreen.vue
@@ -104,10 +104,13 @@ export default {
 				this.timer = null;
 			}
 
+			// Keep the dismissal snappy: the fade starts almost immediately and
+			// `.exiting` turns off pointer-events, so the menu behind becomes
+			// clickable right away instead of ~1.4s later.
 			window.setTimeout(() => {
 				this.exiting = true;
-				window.setTimeout(() => this.$emit("done"), 520);
-			}, 850);
+				window.setTimeout(() => this.$emit("done"), 350);
+			}, 400);
 		},
 
 		startTyping() {
@@ -204,7 +207,7 @@ export default {
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 	opacity: 1;
-	transition: opacity 520ms ease;
+	transition: opacity 350ms ease;
 	outline: none;
 }
 


### PR DESCRIPTION
## Problema
No primeiro load, após clicar na tela de boot, o menu ficava ~1,4s sem responder (relatado como "não consegue clicar em nenhum item do menu").

## Causa
O `enter()` segurava o overlay de tela cheia (z-index 99999) por **850ms** antes de iniciar um fade de **520ms**. Durante isso o app já está visível por baixo, mas o overlay engole os cliques.

## Correção
Tempos reduzidos para 400ms + 350ms (fade CSS acompanhado). `.exiting` já tem `pointer-events: none`, então o clique libera assim que o fade começa.

## Verificação
- Probe com Playwright (clique real pós-boot): tempo até a primeira navegação **1,13s → 0,64s**
- `npm run build` ✓ · vitest ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)