### PR TITLE
chore(dependabot): pausa version updates do npm, mantém os de segurança

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,23 @@
 version: 2
 updates:
+  # VERSION UPDATES PAUSADOS: `open-pull-requests-limit: 0` desliga os PRs de
+  # atualização de rotina. Os PRs de SEGURANÇA continuam vindo normalmente —
+  # a doc do Dependabot diz que "security update pull requests are not subject
+  # to this limit and do not count toward it", e eles dependem da chave
+  # `dependabot_security_updates` do repo, não deste arquivo.
+  #
+  # Para religar: trocar o 0 por 5. Os `groups` abaixo ficam preservados —
+  # inclusive o grupo `vite`, que importa pro upgrade coordenado vite 8 +
+  # plugin-vue 6 ainda pendente (GHSA-gv7w-rqvm-qjhr no esbuild).
+  #
+  # Não usar `ignore` de semver-major como alternativa: `ignore` suprime
+  # também os security updates da dependência, e já tivemos dois fixes de
+  # segurança que EXIGIAM major (react-router 6->7, eslint 9->10).
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: monthly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     groups:
       vite:
         patterns:


### PR DESCRIPTION
Os PRs de rotina do npm viraram ruído: só nesta leva foram bumps de `setup-node`, eslint major e grupos minor-and-patch, competindo por atenção com os PRs de segurança de verdade.

## O que muda

`open-pull-requests-limit: 0` na entrada **npm** desliga os version updates. Os PRs de **segurança seguem 100% intactos** — a [doc do Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference) diz que *"security update pull requests are not subject to this limit and do not count toward it"*, e eles dependem da chave `dependabot_security_updates` do repo, não deste arquivo.

Confirmado empiricamente nesta varredura: os 10 repos que **nunca tiveram** `dependabot.yml` recebem PRs de segurança normalmente — quando liguei a chave em 6 deles, 8 PRs de segurança apareceram na hora, sem nenhum yml.

## `github-actions` fica ATIVO de propósito

Actions **não geram alerta de segurança** do Dependabot (não têm advisory de pacote), então pausá-las deixaria `checkout`/`setup-node` envelhecerem sem nenhum aviso — e o CI já está emitindo warning de deprecação do Node 20 nelas. São ~4 PRs em meses, ruído baixo.

## Por que não `ignore` de semver-major

Era a alternativa óbvia e é uma armadilha: **`ignore` suprime também os security updates** da dependência. Nesta mesma varredura, **dois fixes de segurança exigiam major** — `react-router` 6 → 7 (sem patch na linha 6) e `eslint` 9 → 10 (pra zerar o gate de audit do CI). Um `ignore` de majors teria escondido os dois.

## Reverter

Trocar o `0` por `5`. Os `groups` ficam preservados no arquivo.

Validei que o YAML parseia nos 5 repos e que só a entrada npm mudou — uma config quebrada faria o Dependabot ignorar o arquivo inteiro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)